### PR TITLE
Fix dialog style overrides

### DIFF
--- a/src/components/ui/dialog-fixed.tsx
+++ b/src/components/ui/dialog-fixed.tsx
@@ -40,12 +40,12 @@ const DialogContent = React.forwardRef<
         "fixed left-[50%] top-[50%] z-[9999] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
-      style={{ 
+      style={{
         zIndex: 9999,
-        position: 'fixed !important',
-        top: '50% !important',
-        left: '50% !important',
-        transform: 'translate(-50%, -50%) !important'
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)'
       }}
       {...props}
     >

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -40,12 +40,12 @@ const DialogContent = React.forwardRef<
         "fixed left-[50%] top-[50%] z-[9999] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
-      style={{ 
+      style={{
         zIndex: 9999,
-        position: 'fixed !important',
-        top: '50% !important',
-        left: '50% !important',
-        transform: 'translate(-50%, -50%) !important'
+        position: 'fixed',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)'
       }}
       {...props}
     >


### PR DESCRIPTION
## Summary
- update `DialogPrimitive.Content` style to rely on CSS for positioning

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68894c3fc644832c89cd8cbfbccb58c3