### PR TITLE
Add API base URL support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment variables for Brick Call Sheet Generator
+DATABASE_URL=postgresql://user:password@host:port/database
+PORT=5000
+
+# Optional Supabase credentials for the frontend
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# Base URL for API requests
+VITE_API_BASE_URL=http://localhost:5000
+API_BASE_URL=http://localhost:5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env*
+!.env.example

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ cp .env.example .env
 ```
 Preencha `DATABASE_URL`, `PORT` (opcional) e, se utilizar o Supabase no frontend,
 `VITE_SUPABASE_URL` e `VITE_SUPABASE_ANON_KEY`.
+Defina também `VITE_API_BASE_URL` (ou `API_BASE_URL` no servidor) com a URL
+base da API caso execute código fora do navegador.
 
 ### 3. Instale as dependências
 ```bash
@@ -145,6 +147,8 @@ Se a aplicação não conseguir se conectar ao banco de dados durante o
 início, ela exibirá uma mensagem de erro e encerrará o processo. Verifique
 se a variável `DATABASE_URL` está correta e se o banco está acessível
 antes de reiniciar o servidor.
+Ao executar scripts Node ou testes que utilizem `fetch`, defina
+`API_BASE_URL` ou `VITE_API_BASE_URL` para evitar erros de URL relativa.
 
 ## 🤝 Contribuição
 

--- a/src/data/default-templates.ts
+++ b/src/data/default-templates.ts
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid";
 import type { InsertTemplate } from "@shared/schema";
+import { apiRequest } from "@/lib/api";
 
 export const defaultTemplates: InsertTemplate[] = [
   {
@@ -251,7 +252,7 @@ export async function insertDefaultTemplates() {
 
   try {
     for (const template of templates) {
-      await fetch('/api/templates', {
+      await apiRequest('/api/templates', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(template),

--- a/src/hooks/use-call-sheet-history.tsx
+++ b/src/hooks/use-call-sheet-history.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest } from "@/lib/api";
 import type { CallSheet } from "@shared/schema";
 
 export function useCallSheetHistory() {
@@ -7,14 +7,9 @@ export function useCallSheetHistory() {
     queryKey: ['/api/call-sheets'],
     queryFn: async () => {
       try {
-        const response = await fetch('/api/call-sheets');
-        if (!response.ok) {
-          console.warn('Banco de dados indisponível, usando histórico local');
-          return getLocalHistory();
-        }
-        const data = await response.json() as CallSheet[];
-        return data.sort((a, b) => 
-          new Date(b.updatedAt || b.createdAt || '').getTime() - 
+        const data = await apiRequest('/api/call-sheets') as CallSheet[];
+        return data.sort((a, b) =>
+          new Date(b.updatedAt || b.createdAt || '').getTime() -
           new Date(a.updatedAt || a.createdAt || '').getTime()
         );
       } catch (error) {
@@ -46,13 +41,11 @@ export function useCreateCallSheet() {
   return useMutation({
     mutationFn: async (callSheet: CallSheet) => {
       try {
-        const response = await fetch('/api/call-sheets', {
+        return await apiRequest('/api/call-sheets', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(callSheet),
-        });
-        if (!response.ok) throw new Error('Failed to create call sheet');
-        return response.json();
+        }) as CallSheet;
       } catch (error) {
         console.warn('Salvando ordem do dia localmente devido a erro de conexão:', error);
         return saveCallSheetLocally(callSheet);
@@ -91,10 +84,9 @@ export function useDeleteCallSheet() {
   
   return useMutation({
     mutationFn: async (id: string) => {
-      const response = await fetch(`/api/call-sheets/${id}`, {
+      await apiRequest(`/api/call-sheets/${id}`, {
         method: 'DELETE',
       });
-      if (!response.ok) throw new Error('Failed to delete call sheet');
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['/api/call-sheets'] });

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -3,16 +3,9 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import type { SelectProject, InsertProject } from "@shared/schema";
 import { nanoid } from "nanoid";
+import { apiRequest } from "@/lib/api";
 
 const STORAGE_KEY = "brick-projects";
-
-async function apiRequest(url: string, options?: RequestInit) {
-  const response = await fetch(url, options);
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-  return response.json();
-}
 
 export function useProjects() {
   const queryClient = useQueryClient();

--- a/src/hooks/use-sync-storage.ts
+++ b/src/hooks/use-sync-storage.ts
@@ -3,17 +3,10 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useToast } from "@/hooks/use-toast";
 import type { SelectProject, InsertProject, SelectCallSheet, InsertCallSheet } from "@shared/schema";
 import { nanoid } from "nanoid";
+import { apiRequest } from "@/lib/api";
 
 const PROJECTS_STORAGE_KEY = "brick-projects";
 const CALLSHEETS_STORAGE_KEY = "brick-call-sheets";
-
-async function apiRequest(url: string, options?: RequestInit) {
-  const response = await fetch(url, options);
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
-  return response.json();
-}
 
 // Sistema de sincronização inteligente
 export function useSyncProjects() {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,15 @@
+const API_BASE =
+  typeof window === 'undefined'
+    ? process.env.API_BASE_URL || ''
+    : import.meta.env.VITE_API_BASE_URL || '';
+
+export async function apiRequest(path: string, options?: RequestInit) {
+  const url = new URL(path, API_BASE).toString();
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  return response.json();
+}
+
+export { API_BASE };

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
+import { API_BASE } from "@/lib/api";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
@@ -12,7 +13,8 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
-  const res = await fetch(url, {
+  const fullUrl = new URL(url, API_BASE).toString();
+  const res = await fetch(fullUrl, {
     method,
     headers: data ? { "Content-Type": "application/json" } : {},
     body: data ? JSON.stringify(data) : undefined,
@@ -29,7 +31,8 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
+    const url = new URL(queryKey.join("/") as string, API_BASE).toString();
+    const res = await fetch(url, {
       credentials: "include",
     });
 


### PR DESCRIPTION
## Summary
- create `.env.example` with API_BASE_URL vars
- document new variables in README
- centralize `apiRequest` in `src/lib/api.ts`
- use `apiRequest` and base URL in hooks and utilities
- allow `.env.example` in version control
- update query client to use API_BASE_URL

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a9e7f975c832c8873dbe443cbbf3a