### PR TITLE
Fix server HTML paths

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -48,7 +48,6 @@ export async function setupVite(app: Express, server: Server) {
       const clientTemplate = path.resolve(
         import.meta.dirname,
         "..",
-        "client",
         "index.html",
       );
 
@@ -68,7 +67,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  const distPath = path.resolve(import.meta.dirname, "..", "public");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
## Summary
- point dev server at index.html under project root
- adjust production static path

## Testing
- `npm run dev` (with PostgreSQL running)
- `curl http://localhost:5000` in dev and production

------
https://chatgpt.com/codex/tasks/task_e_688ae438f720832c9c32647b1a7fc706