### PR TITLE
Handle missing DB gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ A aplicação segue a identidade visual da Brick Produtora:
 
 ## 🔧 Solução de Problemas
 
-Se a aplicação não conseguir se conectar ao banco de dados durante o
-início, ela exibirá uma mensagem de erro e encerrará o processo. Verifique
-se a variável `DATABASE_URL` está correta e se o banco está acessível
-antes de reiniciar o servidor.
+Caso a aplicação não consiga se conectar ao banco durante o início
+(ou se `DATABASE_URL` não estiver definida), ela continuará em modo de
+armazenamento em memória. Verifique a variável `DATABASE_URL` e a
+acessibilidade do banco para voltar a persistir os dados.
 Ao executar scripts Node ou testes que utilizem `fetch`, defina
 `API_BASE_URL` ou `VITE_API_BASE_URL` para evitar erros de URL relativa.
 

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,34 +2,38 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from "@shared/schema";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
-  );
+let db: ReturnType<typeof drizzle> | null = null;
+let client: postgres.Sql | null = null;
+
+if (process.env.DATABASE_URL) {
+  // Configure postgres client for Railway with proper SSL and auth settings
+  client = postgres(process.env.DATABASE_URL, {
+    prepare: false,
+    ssl: 'prefer',
+    max: 1,
+    idle_timeout: 20,
+    connect_timeout: 10,
+    // Configurações específicas para pooling do Railway
+    connection: {
+      application_name: 'brick_call_sheet_app'
+    }
+  });
+
+  db = drizzle(client, { schema });
+} else {
+  console.warn('DATABASE_URL not set – falling back to in-memory storage');
 }
 
-// Configure postgres client for Railway with proper SSL and auth settings
-const client = postgres(process.env.DATABASE_URL, { 
-  prepare: false,
-  ssl: 'prefer',
-  max: 1,
-  idle_timeout: 20,
-  connect_timeout: 10,
-  // Configurações específicas para pooling do Railway
-  connection: {
-    application_name: 'brick_call_sheet_app'
-  }
-});
-
-export const db = drizzle(client, { schema });
+export { db };
 
 // Test connection and log status
 export async function testConnection() {
+  if (!client) return false;
   try {
     await client`SELECT 1`;
     console.log('✅ Database connection successful');
     return true;
-  } catch (error) {
+  } catch (error: any) {
     console.error('❌ Database connection failed:', error.message);
     return false;
   }


### PR DESCRIPTION
## Summary
- allow starting the server without `DATABASE_URL`
- clarify README troubleshooting section

## Testing
- `npm run build`
- `npx tsc -p tsconfig.json` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_688aeef9eda0832c809c184598684f6d