### PR TITLE
Fix production build path, DB fallback and docs

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,0 @@
-#Brick Call Sheet Generator
-DATABASE_URL=postgresql://postgres:cwkvtPTCdASRQUBrLEvrnIkPJeJheerS@shinkansen.proxy.rlwy.net:42132/railway
-PORT=5000
-
-# Base URL for API requests
-VITE_API_BASE_URL=http://localhost:5000
-API_BASE_URL=http://localhost:5000

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ cd gerador-ordem-do-dia
 cp .env.example .env
 ```
 Preencha `DATABASE_URL` e `PORT` (opcional).
+Nunca envie o arquivo `.env` para o repositório, use-o apenas localmente.
 Defina também `VITE_API_BASE_URL` (ou `API_BASE_URL` no servidor) com a URL
 base da API caso execute código fora do navegador.
 
@@ -102,7 +103,12 @@ A aplicação estará disponível em `http://localhost:5000`
 
 ### Executar no Railway
 
-Em um serviço **Node** do Railway utilize:
+Antes de iniciar em modo produção é necessário gerar os arquivos estáticos:
+```bash
+npm run build
+```
+
+Em um serviço **Node** do Railway utilize em seguida:
 ```bash
 npm start
 ```

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -9,8 +9,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Test database connection on startup
   const connected = await testConnection();
   if (!connected) {
-    console.error('❌ Unable to connect to the database. Exiting...');
-    process.exit(1);
+    console.warn('❌ Unable to connect to the database. Falling back to in-memory storage.');
   }
   // Call Sheet routes
   app.get("/api/call-sheets", async (req, res) => {

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -67,7 +67,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "..", "public");
+  const distPath = path.resolve(import.meta.dirname, "..", "dist");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(


### PR DESCRIPTION
## Summary
- align static file path with Vite build output
- keep server running when the database connection fails
- remove accidentally committed `.env`
- clarify `.env` usage and add build step to README

## Testing
- `npm run build`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_688cec74cb18832ca9398cc440d4b830