### PR TITLE
Add .env example and update env usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Example environment variables for Brick Call Sheet Generator
-DATABASE_URL=postgresql://postgres:cwkvtPTCdASRQUBrLEvrnIkPJeJheerS@shinkansen.proxy.rlwy.net:42132/railway
+DATABASE_URL=
 PORT=5000
 # Base URL for API requests (use HTTPS or leave blank in production)
-VITE_API_BASE_URL=
-API_BASE_URL=
+VITE_API_BASE_URL=https://<your-domain>
+API_BASE_URL=https://<your-domain>

--- a/README.md
+++ b/README.md
@@ -38,14 +38,11 @@ git clone https://github.com/seu-usuario/gerador-ordem-do-dia.git
 cd gerador-ordem-do-dia
 ```
 
-### 2. Copie o arquivo de variáveis de ambiente
-```bash
-cp .env.example .env
-```
+### 2. Configure as variáveis de ambiente
+Use o arquivo `.env.example` como referência para criar o seu `.env`.
 Preencha `DATABASE_URL` e `PORT` (opcional).
-Nunca envie o arquivo `.env` para o repositório, use-o apenas localmente.
-Defina também `VITE_API_BASE_URL` (ou `API_BASE_URL` no servidor) com a URL
-base da API caso execute código fora do navegador.
+As variáveis `VITE_API_BASE_URL` e `API_BASE_URL` devem apontar para um domínio HTTPS ou permanecer vazias em produção.
+Nunca envie o arquivo `.env` para o repositório.
 
 ### 3. Instale as dependências
 ```bash
@@ -161,7 +158,8 @@ Caso a aplicação não consiga se conectar ao banco durante o início
 armazenamento em memória. Verifique a variável `DATABASE_URL` e a
 acessibilidade do banco para voltar a persistir os dados.
 Ao executar scripts Node ou testes que utilizem `fetch`, defina
-`API_BASE_URL` ou `VITE_API_BASE_URL` para evitar erros de URL relativa.
+`API_BASE_URL` ou `VITE_API_BASE_URL`. Em produção essas variáveis devem
+usar HTTPS ou permanecer vazias para evitar avisos de conteúdo misto.
 
 ## 🤝 Contribuição
 


### PR DESCRIPTION
## Summary
- add example environment file
- update default `.env` values to avoid mixed content
- clarify environment variable instructions in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d30091b7c832ca6fa05256d4648a7