### PR TITLE
Fix API base handling and update deploy docs

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -46,7 +46,8 @@ npm run build
 
 1. Conecte o repositório no [Railway](https://railway.app)
 2. Configure a variável `DATABASE_URL`
-3. Railway fará o deploy automaticamente
+3. No console do Railway, execute `npm run db:push` para criar as tabelas
+4. Railway fará o deploy automaticamente
 
 ### 3. Render
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,7 +4,7 @@ const API_BASE =
     : import.meta.env.VITE_API_BASE_URL || '';
 
 export async function apiRequest(path: string, options?: RequestInit) {
-  const url = new URL(path, API_BASE).toString();
+  const url = API_BASE ? new URL(path, API_BASE).toString() : path;
   const response = await fetch(url, options);
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## Summary
- avoid URL parsing errors when API_BASE_URL is empty
- document `npm run db:push` in Railway deploy steps

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688d32de803c832c907fcc49929c6bed