### PR TITLE
Fix API base usage in query client

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -46,7 +46,10 @@ npm run build
 
 1. Conecte o repositório no [Railway](https://railway.app)
 2. Configure a variável `DATABASE_URL`
-3. Railway fará o deploy automaticamente
+3. Defina `VITE_API_BASE_URL` (ou `API_BASE_URL`) com o domínio HTTPS do
+   Railway ou deixe em branco para usar caminhos relativos
+4. No console do Railway, execute `npm run db:push` para criar as tabelas
+5. Railway fará o deploy automaticamente
 
 ### 3. Render
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,7 +4,7 @@ const API_BASE =
     : import.meta.env.VITE_API_BASE_URL || '';
 
 export async function apiRequest(path: string, options?: RequestInit) {
-  const url = new URL(path, API_BASE).toString();
+  const url = API_BASE ? new URL(path, API_BASE).toString() : path;
   const response = await fetch(url, options);
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -13,7 +13,7 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
-  const fullUrl = new URL(url, API_BASE).toString();
+  const fullUrl = API_BASE ? new URL(url, API_BASE).toString() : url;
   const res = await fetch(fullUrl, {
     method,
     headers: data ? { "Content-Type": "application/json" } : {},
@@ -31,7 +31,8 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const url = new URL(queryKey.join("/") as string, API_BASE).toString();
+    const path = queryKey.join("/") as string;
+    const url = API_BASE ? new URL(path, API_BASE).toString() : path;
     const res = await fetch(url, {
       credentials: "include",
     });


### PR DESCRIPTION
## Summary
- avoid new URL failures in queryClient when API base is empty
- clarify API_BASE_URL setup in Railway docs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d32de803c832c907fcc49929c6bed