### PR TITLE
Add hover shadow for brand buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -91,6 +91,7 @@
   
   .brick-red-hover:hover {
     background-color: var(--brick-red-hover);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
   }
   
   .text-brick-black {


### PR DESCRIPTION
## Summary
- add drop shadow on `.brick-red-hover` style so buttons stay visible on hover

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d3cd3d214832c86f8ab775bf1babd