### PR TITLE
feat: add brick button variant

### DIFF
--- a/src/components/brick-header.tsx
+++ b/src/components/brick-header.tsx
@@ -27,9 +27,10 @@ export default function BrickHeader({ onExportPDF, onSave, hasUnsavedChanges }: 
             </div>
           </div>
           <div className="flex items-center space-x-4">
-            <Button 
+            <Button
               onClick={onExportPDF}
-              className="brick-red brick-red-hover text-white px-4 py-2 rounded-lg font-medium transition-colors"
+              variant="brick"
+              className="px-4 py-2 rounded-lg font-medium transition-colors"
             >
               <FileText className="w-4 h-4 mr-2" />
               Gerar PDF

--- a/src/components/projects-manager.tsx
+++ b/src/components/projects-manager.tsx
@@ -228,9 +228,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
           }
         }}>
           <DialogTrigger asChild>
-            <Button 
+            <Button
               onClick={() => setShowNewProjectDialog(true)}
-              className="brick-red brick-red-hover text-white"
+              variant="brick"
             >
               <Plus className="w-4 h-4 mr-2" />
               Novo Projeto

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,6 +18,8 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        brick:
+          "bg-[var(--brick-red)] text-white hover:bg-[var(--brick-red-hover)] hover:text-white",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/pages/call-sheet-generator.tsx
+++ b/src/pages/call-sheet-generator.tsx
@@ -500,7 +500,8 @@ export default function CallSheetGenerator() {
           
           <Button
             onClick={handleExportPDF}
-            className="brick-red brick-red-hover text-white px-8 py-3 rounded-lg font-semibold transition-colors flex items-center text-lg"
+            variant="brick"
+            className="px-8 py-3 rounded-lg font-semibold transition-colors flex items-center text-lg"
           >
             <FileText className="w-5 h-5 mr-2" />
             Gerar PDF


### PR DESCRIPTION
## Summary
- add `brick` button variant with custom red styling
- use `brick` variant for "Novo Projeto" and "Gerar PDF" buttons

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`
- `node - <<'NODE' ... NODE` (hover color check)

------
https://chatgpt.com/codex/tasks/task_e_688e84cb4424832c8ea799173d78fd3f