### PR TITLE
fix: use brick variant for save template button

### DIFF
--- a/src/pages/call-sheet-generator.tsx
+++ b/src/pages/call-sheet-generator.tsx
@@ -489,7 +489,8 @@ export default function CallSheetGenerator() {
                   <Button
                     onClick={handleSaveAsTemplate}
                     disabled={createTemplateMutation.isPending}
-                    className="brick-red brick-red-hover"
+                    variant="brick"
+                    className="text-white"
                   >
                     {createTemplateMutation.isPending ? "Salvando..." : "Salvar Template"}
                   </Button>


### PR DESCRIPTION
## Summary
- ensure save template button uses brick variant with white text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e8976e9f8832cbb47cc11e220dadd