### PR TITLE
feat(header): add hover background to save button

### DIFF
--- a/src/components/brick-header.tsx
+++ b/src/components/brick-header.tsx
@@ -38,7 +38,7 @@ export default function BrickHeader({ onExportPDF, onSave, hasUnsavedChanges }: 
             <Button
               onClick={onSave}
               variant="ghost"
-              className={`text-gray-300 hover:text-white transition-colors ${hasUnsavedChanges ? 'text-yellow-400' : ''}`}
+              className={`text-gray-300 hover:text-white hover:bg-[var(--brick-red)] transition-colors ${hasUnsavedChanges ? 'text-yellow-400' : ''}`}
             >
               <Save className="w-5 h-5" />
             </Button>


### PR DESCRIPTION
## Summary
- add contrasting hover background to save button in brick header

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688e8d49aaf8832c8e5abd4019d2a914