### PR TITLE
feat: refine ghost icon buttons

### DIFF
--- a/src/components/call-times-section.tsx
+++ b/src/components/call-times-section.tsx
@@ -113,7 +113,7 @@ export default function CallTimesSection({
                       <span className="text-sm font-medium text-gray-700">Membro da Equipe</span>
                       <Button
                         onClick={() => onRemoveCrew(callTime.id)}
-                        variant="ghost"
+                        variant="iconGhost"
                         size="sm"
                         className="text-gray-400 hover:text-red-500 transition-colors"
                       >
@@ -207,7 +207,7 @@ export default function CallTimesSection({
                     />
                     <Button
                       onClick={() => onRemoveCast(callTime.id)}
-                      variant="ghost"
+                      variant="iconGhost"
                       size="sm"
                       className="text-gray-400 hover:text-red-500 transition-colors"
                     >

--- a/src/components/contacts-section.tsx
+++ b/src/components/contacts-section.tsx
@@ -74,7 +74,7 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
         </div>
         <Button
           onClick={() => onRemove(contact.id)}
-          variant="ghost"
+          variant="iconGhost"
           size="sm"
           className="text-gray-400 hover:text-red-500 transition-colors"
         >

--- a/src/components/locations-section.tsx
+++ b/src/components/locations-section.tsx
@@ -74,7 +74,7 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
         </div>
         <Button
           onClick={() => onRemove(location.id)}
-          variant="ghost"
+          variant="iconGhost"
           size="sm"
           className="text-gray-400 hover:text-red-500 transition-colors"
         >

--- a/src/components/scenes-section.tsx
+++ b/src/components/scenes-section.tsx
@@ -75,7 +75,7 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
         </div>
         <Button
           onClick={() => onRemove(scene.id)}
-          variant="ghost"
+          variant="iconGhost"
           size="sm"
           className="text-gray-400 hover:text-red-500 transition-colors"
         >

--- a/src/components/script-section.tsx
+++ b/src/components/script-section.tsx
@@ -151,9 +151,9 @@ export default function ScriptSection({
                 </Button>
                 <Button
                   onClick={clearScript}
-                  variant="ghost"
+                  variant="iconGhost"
                   size="sm"
-                  className="text-gray-500 hover:text-red-500"
+                  className="text-gray-500 hover:text-red-500 transition-colors"
                 >
                   <X className="w-4 h-4" />
                 </Button>
@@ -355,9 +355,9 @@ export default function ScriptSection({
                     </Button>
                     <Button
                       onClick={() => onRemoveAttachment(attachment.id)}
-                      variant="ghost"
+                      variant="iconGhost"
                       size="sm"
-                      className="text-gray-500 hover:text-red-500"
+                      className="text-gray-500 hover:text-red-500 transition-colors"
                     >
                       <X className="w-4 h-4" />
                     </Button>

--- a/src/components/template-manager.tsx
+++ b/src/components/template-manager.tsx
@@ -242,9 +242,9 @@ export function TemplateManager({ onSelectTemplate, currentCallSheet }: Template
                     </Badge>
                   </div>
                   <Button
-                    variant="ghost"
+                    variant="iconGhost"
                     size="sm"
-                    className="opacity-0 group-hover:opacity-100 transition-opacity"
+                    className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500"
                     onClick={() => handleDeleteTemplate(template.id, template.name)}
                   >
                     <Trash2 className="w-4 h-4" />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,6 +17,7 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
+        iconGhost: "hover:bg-transparent",
         link: "text-primary underline-offset-4 hover:underline",
         brick:
           "bg-[var(--brick-red)] text-white hover:bg-[var(--brick-red-hover)] hover:text-white",


### PR DESCRIPTION
## Summary
- add `iconGhost` button variant without accent hover
- apply transparent hover and red text to remove buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e8d4d1ba0832ca8d801061854be73