### PR TITLE
feat: add brick outline button variant

### DIFF
--- a/src/components/contacts-section.tsx
+++ b/src/components/contacts-section.tsx
@@ -159,9 +159,10 @@ export default function ContactsSection({
             </div>
             <h2 className="text-xl font-semibold text-brick-dark">Contatos Importantes</h2>
           </div>
-          <Button 
+          <Button
             onClick={onAdd}
-            className="brick-red brick-red-hover text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            variant="brick"
+            className="text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
           >
             <Plus className="w-4 h-4 mr-2" />
             Novo Contato

--- a/src/components/locations-section.tsx
+++ b/src/components/locations-section.tsx
@@ -146,9 +146,10 @@ export default function LocationsSection({
             </div>
             <h2 className="text-xl font-semibold text-brick-dark">Locações</h2>
           </div>
-          <Button 
+          <Button
             onClick={onAdd}
-            className="brick-red brick-red-hover text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            variant="brick"
+            className="text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
           >
             <Plus className="w-4 h-4 mr-2" />
             Nova Locação

--- a/src/components/scenes-section.tsx
+++ b/src/components/scenes-section.tsx
@@ -170,9 +170,10 @@ export default function ScenesSection({
             </div>
             <h2 className="text-xl font-semibold text-brick-dark">Cenas Programadas</h2>
           </div>
-          <Button 
+          <Button
             onClick={onAdd}
-            className="brick-red brick-red-hover text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            variant="brick"
+            className="text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
           >
             <Plus className="w-4 h-4 mr-2" />
             Nova Cena

--- a/src/components/script-section.tsx
+++ b/src/components/script-section.tsx
@@ -229,11 +229,7 @@ export default function ScriptSection({
             <h3 className="text-lg font-medium text-gray-900">Outros Arquivos</h3>
             <Dialog open={showAddDialog} onOpenChange={setShowAddDialog}>
               <DialogTrigger asChild>
-                <Button 
-                  variant="outline" 
-                  size="sm"
-                  className="text-brick-red border-brick-red hover:bg-brick-red hover:text-white"
-                >
+                <Button variant="outlineBrick" size="sm">
                   <Plus className="w-4 h-4 mr-1" />
                   Adicionar Arquivo
                 </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -21,6 +21,8 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
         brick:
           "bg-[var(--brick-red)] text-white hover:bg-[var(--brick-red-hover)] hover:text-white",
+        outlineBrick:
+          "border border-brick-red bg-background text-brick-red hover:bg-[var(--brick-red)] hover:text-white",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/pages/call-sheet-generator.tsx
+++ b/src/pages/call-sheet-generator.tsx
@@ -428,8 +428,8 @@ export default function CallSheetGenerator() {
           <Dialog open={showTemplateDialog} onOpenChange={setShowTemplateDialog}>
             <DialogTrigger asChild>
               <Button
-                variant="outline"
-                className="border-brick-red text-brick-red hover:bg-brick-red hover:text-white px-6 py-3 rounded-lg font-semibold transition-colors flex items-center text-lg"
+                variant="outlineBrick"
+                className="px-6 py-3 rounded-lg font-semibold transition-colors flex items-center text-lg"
               >
                 <Layout className="w-5 h-5 mr-2" />
                 Salvar como Template


### PR DESCRIPTION
## Summary
- add outlineBrick button variant for brick-themed outline
- switch affected buttons to outlineBrick or brick variant, removing redundant classes

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e922a399c832c8d271ce23bacf2c2