### PR TITLE
feat: add team members management page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,14 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import CallSheetGenerator from "@/pages/call-sheet-generator";
+import TeamMembers from "@/pages/team-members";
 import NotFound from "@/pages/not-found";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={CallSheetGenerator} />
+      <Route path="/team-members" component={TeamMembers} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/src/pages/team-members.tsx
+++ b/src/pages/team-members.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/api";
+
+interface TeamMember {
+  id: string;
+  name: string;
+  role: string;
+}
+
+export default function TeamMembers() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [role, setRole] = useState("");
+  const [editing, setEditing] = useState<TeamMember | null>(null);
+
+  const { data: members } = useQuery<TeamMember[]>({
+    queryKey: ["/api/team-members"],
+    queryFn: () => apiRequest("/api/team-members"),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: Omit<TeamMember, "id">) =>
+      apiRequest("/api/team-members", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/team-members"] });
+      toast({ title: "Membro adicionado" });
+      setName("");
+      setRole("");
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (data: TeamMember) =>
+      apiRequest(`/api/team-members/${data.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/team-members"] });
+      toast({ title: "Membro atualizado" });
+      setEditing(null);
+      setName("");
+      setRole("");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) =>
+      apiRequest(`/api/team-members/${id}`, { method: "DELETE" }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/team-members"] });
+      toast({ title: "Membro removido" });
+    },
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !role.trim()) return;
+    if (editing) {
+      updateMutation.mutate({ ...editing, name: name.trim(), role: role.trim() });
+    } else {
+      createMutation.mutate({ name: name.trim(), role: role.trim() });
+    }
+  };
+
+  const handleEdit = (member: TeamMember) => {
+    setEditing(member);
+    setName(member.name);
+    setRole(member.role);
+  };
+
+  const handleCancel = () => {
+    setEditing(null);
+    setName("");
+    setRole("");
+  };
+
+  return (
+    <div className="p-4 space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>{editing ? "Editar membro" : "Adicionar membro"}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="flex flex-col md:flex-row gap-2">
+            <Input
+              placeholder="Nome"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="md:w-1/3"
+            />
+            <Input
+              placeholder="Função"
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              className="md:w-1/3"
+            />
+            <Button type="submit">
+              {editing ? "Atualizar" : "Adicionar"}
+            </Button>
+            {editing && (
+              <Button type="button" variant="outline" onClick={handleCancel}>
+                Cancelar
+              </Button>
+            )}
+          </form>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Membros da equipe</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nome</TableHead>
+                <TableHead>Função</TableHead>
+                <TableHead className="w-[150px]">Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members?.map((member) => (
+                <TableRow key={member.id}>
+                  <TableCell>{member.name}</TableCell>
+                  <TableCell>{member.role}</TableCell>
+                  <TableCell>
+                    <div className="flex gap-2">
+                      <Button size="sm" variant="secondary" onClick={() => handleEdit(member)}>
+                        Editar
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => deleteMutation.mutate(member.id)}
+                      >
+                        Excluir
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {(!members || members.length === 0) && (
+                <TableRow>
+                  <TableCell colSpan={3} className="text-center">
+                    Nenhum membro encontrado
+                  </TableCell>
+                </TableRow>
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `/team-members` route
- implement team members CRUD page using `/api/team-members`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ffff63c74832cb12f09aa82fa99ab