### PR TITLE
feat: add team member selection for crew call times

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -34,6 +34,7 @@ export const attachmentSchema = z.object({
 export const callTimeSchema = z.object({
   id: z.string(),
   time: z.string(),
+  memberId: z.string().optional(),
   name: z.string(),
   role: z.string(),
   phone: z.string().optional(),

--- a/src/components/call-times-section.tsx
+++ b/src/components/call-times-section.tsx
@@ -3,7 +3,14 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
-import { CallTime } from "@shared/schema";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import type { CallTime, TeamMember } from "@shared/schema";
 
 interface CallTimesSectionProps {
   crewCallTimes: CallTime[];
@@ -18,9 +25,10 @@ interface CallTimesSectionProps {
   onUpdateCast: (id: string, updates: Partial<CallTime>) => void;
   onRemoveCast: (id: string) => void;
   onUpdateField: (field: any, value: any) => void;
+  members: TeamMember[];
 }
 
-export default function CallTimesSection({ 
+export default function CallTimesSection({
   crewCallTimes,
   castCallTimes,
   startTime,
@@ -32,7 +40,8 @@ export default function CallTimesSection({
   onAddCast,
   onUpdateCast,
   onRemoveCast,
-  onUpdateField
+  onUpdateField,
+  members
 }: CallTimesSectionProps) {
   return (
     <Card className="mb-8">
@@ -109,8 +118,37 @@ export default function CallTimesSection({
               <div className="space-y-3">
                 {crewCallTimes.map((callTime) => (
                   <div key={callTime.id} className="space-y-2 p-3 bg-gray-50 rounded-lg">
-                    <div className="flex items-center justify-between">
-                      <span className="text-sm font-medium text-gray-700">Membro da Equipe</span>
+                    <div className="flex items-start justify-between">
+                      <div className="w-full mr-2">
+                        <Label className="text-xs text-gray-600 mb-1 block">Membro da Equipe</Label>
+                        <Select
+                          value={callTime.memberId || undefined}
+                          onValueChange={(value) => {
+                            const member = members.find((m) => m.id === value);
+                            if (member) {
+                              onUpdateCrew(callTime.id, {
+                                memberId: member.id,
+                                name: member.name,
+                                role: member.role || '',
+                                phone: member.phone || '',
+                              });
+                            } else {
+                              onUpdateCrew(callTime.id, { memberId: undefined });
+                            }
+                          }}
+                        >
+                          <SelectTrigger className="w-full px-3 py-2 text-sm">
+                            <SelectValue placeholder="Selecione um membro" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {members.map((member) => (
+                              <SelectItem key={member.id} value={member.id}>
+                                {member.name}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </div>
                       <Button
                         onClick={() => onRemoveCrew(callTime.id)}
                         variant="iconGhost"

--- a/src/hooks/use-call-sheet.tsx
+++ b/src/hooks/use-call-sheet.tsx
@@ -158,6 +158,8 @@ export function useCallSheet() {
       time: "",
       name: "",
       role: "",
+      phone: "",
+      memberId: undefined,
     };
     setCallSheet(prev => ({
       ...prev,

--- a/src/pages/call-sheet-generator.tsx
+++ b/src/pages/call-sheet-generator.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { StickyNote, Save, FileText, Eye, Layers, History, Layout, FolderOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
@@ -13,6 +14,7 @@ import { useCallSheet } from "@/hooks/use-call-sheet";
 import { useCreateCallSheet } from "@/hooks/use-call-sheet-history";
 import { useCreateTemplate } from "@/hooks/use-templates";
 import { generateCallSheetPDF } from "@/lib/pdf-generator";
+import { apiRequest } from "@/lib/api";
 
 import BrickHeader from "@/components/brick-header";
 import BrickFooter from "@/components/brick-footer";
@@ -28,7 +30,7 @@ import { CallSheetHistory } from "@/components/call-sheet-history";
 import { ProjectsManager } from "@/components/projects-manager";
 import { ProjectCallSheets } from "@/components/project-call-sheets";
 import { useProjectCallSheets } from "@/hooks/use-project-call-sheets";
-import type { CallSheet, Project } from "@shared/schema";
+import type { CallSheet, Project, TeamMember } from "@shared/schema";
 
 export default function CallSheetGenerator() {
   const { toast } = useToast();
@@ -41,9 +43,13 @@ export default function CallSheetGenerator() {
   const [templateCategory, setTemplateCategory] = useState("produção");
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
   const [currentProjectId, setCurrentProjectId] = useState<string | undefined>(undefined);
-  
+
   const createCallSheet = useCreateCallSheet();
   const createTemplateMutation = useCreateTemplate();
+  const { data: members } = useQuery<TeamMember[]>({
+    queryKey: ["/api/team-members"],
+    queryFn: () => apiRequest("/api/team-members"),
+  });
   const {
     callSheet,
     hasUnsavedChanges,
@@ -394,6 +400,7 @@ export default function CallSheetGenerator() {
           onUpdateCast={updateCastCallTime}
           onRemoveCast={removeCastCallTime}
           onUpdateField={updateField}
+          members={members || []}
         />
 
         {/* General Notes Section */}


### PR DESCRIPTION
## Summary
- support selecting team members for crew call times with automatic field population
- store memberId in call time schema and state
- load team members on call sheet generator init and pass to call times section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890025ff53c832c88252eb0ed8911b4