### PR TITLE
Add error toasts for team member mutations

### DIFF
--- a/src/pages/team-members.tsx
+++ b/src/pages/team-members.tsx
@@ -49,6 +49,16 @@ export default function TeamMembers() {
       setPhone("");
       setProjectId(undefined);
     },
+    onError: (error: unknown) => {
+      toast({
+        title: "Erro ao adicionar membro",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Não foi possível adicionar o membro.",
+        variant: "destructive",
+      });
+    },
   });
 
   const updateMutation = useMutation({
@@ -68,6 +78,16 @@ export default function TeamMembers() {
       setPhone("");
       setProjectId(undefined);
     },
+    onError: (error: unknown) => {
+      toast({
+        title: "Erro ao atualizar membro",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Não foi possível atualizar o membro.",
+        variant: "destructive",
+      });
+    },
   });
 
   const deleteMutation = useMutation({
@@ -76,6 +96,16 @@ export default function TeamMembers() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/team-members"] });
       toast({ title: "Membro removido" });
+    },
+    onError: (error: unknown) => {
+      toast({
+        title: "Erro ao remover membro",
+        description:
+          error instanceof Error
+            ? error.message
+            : "Não foi possível remover o membro.",
+        variant: "destructive",
+      });
     },
   });
 


### PR DESCRIPTION
## Summary
- display descriptive error toasts when creating, updating, or deleting team members fails

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890aff53c58832c8821567992b8f51d