### PR TITLE
fix: omit id and timestamps in team member insert schema

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -194,7 +194,8 @@ export const insertTemplateSchema = createInsertSchema(templates).omit({
   updatedAt: true,
 });
 
-export const insertTeamMemberSchema = teamMemberSchema.omit({ id: true });
+export const insertTeamMemberSchema = teamMemberSchema.omit({
+  id: true,
   createdAt: true,
   updatedAt: true,
 });


### PR DESCRIPTION
## Summary
- omit id, createdAt, and updatedAt from insertTeamMemberSchema

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890e36e9bdc832c9317fd05f27eed5c