### PR TITLE
Add back button to team members page

### DIFF
--- a/src/pages/team-members.tsx
+++ b/src/pages/team-members.tsx
@@ -8,6 +8,7 @@ import { BrickHeader, BrickFooter } from "@/components";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/api";
 import { Plus } from "lucide-react";
+import { Link } from "wouter";
 
 interface TeamMember {
   id: string;
@@ -157,6 +158,9 @@ export default function TeamMembers() {
         hasUnsavedChanges={false}
       />
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
+        <Link href="/" className="block w-fit">
+          <Button variant="ghost">Voltar</Button>
+        </Link>
         <Card>
           <CardHeader>
             <CardTitle>{editing ? "Editar membro" : "Adicionar membro"}</CardTitle>


### PR DESCRIPTION
## Summary
- add back navigation link using wouter on the team members page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890e7b8f048832cae0bad247433f91e