### PR TITLE
style: use outline button variant on team members page

### DIFF
--- a/src/pages/team-members.tsx
+++ b/src/pages/team-members.tsx
@@ -159,7 +159,7 @@ export default function TeamMembers() {
       />
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-4">
         <Link href="/" className="block w-fit">
-          <Button variant="ghost">Voltar</Button>
+          <Button variant="outlineBrick">Voltar</Button>
         </Link>
         <Card>
           <CardHeader>


### PR DESCRIPTION
## Summary
- use `outlineBrick` variant for team members back button

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890ec56a124832ca2da603025810a13