### PR TITLE
feat: label save button in header

### DIFF
--- a/src/components/brick-header.tsx
+++ b/src/components/brick-header.tsx
@@ -48,9 +48,10 @@ export default function BrickHeader({ onExportPDF, onSave, hasUnsavedChanges }: 
             <Button
               onClick={onSave}
               variant="ghost"
-              className={`text-gray-300 hover:text-white hover:bg-[var(--brick-red)] transition-colors ${hasUnsavedChanges ? 'text-yellow-400' : ''}`}
+              className={`${hasUnsavedChanges ? 'text-yellow-400' : 'text-gray-300'} hover:text-white hover:bg-[var(--brick-red)] transition-colors`}
             >
-              <Save className="w-5 h-5" />
+              <Save className="w-4 h-4 mr-2" />
+              Salvar OD
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- label the save action with "Salvar OD" and keep onSave handler
- tweak save icon and styling to match other header buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890fb038304832c8e1cb61857c824d1