### PR TITLE
feat: add save action button

### DIFF
--- a/src/pages/call-sheet-generator.tsx
+++ b/src/pages/call-sheet-generator.tsx
@@ -505,7 +505,16 @@ export default function CallSheetGenerator() {
               </div>
             </DialogContent>
           </Dialog>
-          
+
+          <Button
+            onClick={handleSave}
+            variant="brick"
+            className="px-8 py-3 rounded-lg font-semibold transition-colors flex items-center text-lg"
+          >
+            <Save className="w-5 h-5 mr-2" />
+            Salvar OD
+          </Button>
+
           <Button
             onClick={handleExportPDF}
             variant="brick"


### PR DESCRIPTION
## Summary
- add `Salvar OD` action button next to template and PDF buttons
- reuse existing saving logic via `handleSave`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890ff775694832c8f99201fcac0b8d4