### PR TITLE
feat: add project duplication

### DIFF
--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -231,6 +231,17 @@ export function useProjects() {
     deleteProject: (id: string) => {
       return deleteMutation.mutate(id);
     },
+    duplicateProject: (original: SelectProject, name: string) => {
+      const newId = nanoid();
+      createMutation.mutate({
+        id: newId,
+        name,
+        description: original.description || '',
+        client: original.client || '',
+        status: original.status || 'ativo'
+      });
+      return newId;
+    },
     getProject: (id: string) => {
       const projects = query.data || [];
       return projects.find((project: SelectProject) => project.id === id);


### PR DESCRIPTION
## Summary
- add duplicateProject helper in useProjects
- enable duplicating projects from manager dropdown and copy call sheets

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689101ac51b8832c9e0a05ec921f2b30