### PR TITLE
refactor: use brick button variants

### DIFF
--- a/src/components/call-sheet-history.tsx
+++ b/src/components/call-sheet-history.tsx
@@ -117,9 +117,8 @@ export function CallSheetHistory({ onSelectCallSheet }: CallSheetHistoryProps) {
                 <div className="flex gap-2">
                   <Button
                     size="sm"
-                    variant="outline"
+                    variant="outlineBrick"
                     onClick={() => onSelectCallSheet(callSheet)}
-                    className="border-brick-red text-brick-red hover:bg-brick-red hover:text-white"
                   >
                     <Eye className="w-4 h-4 mr-1" />
                     Carregar

--- a/src/components/call-times-section.tsx
+++ b/src/components/call-times-section.tsx
@@ -102,9 +102,8 @@ export default function CallTimesSection({
               </h3>
               <Button
                 onClick={onAddCrew}
-                variant="outline"
+                variant="outlineBrick"
                 size="sm"
-                className="text-brick-red border-brick-red hover:bg-brick-red hover:text-white"
               >
                 <Plus className="w-4 h-4" />
               </Button>
@@ -214,9 +213,8 @@ export default function CallTimesSection({
               </h3>
               <Button
                 onClick={onAddCast}
-                variant="outline"
+                variant="outlineBrick"
                 size="sm"
-                className="text-brick-red border-brick-red hover:bg-brick-red hover:text-white"
               >
                 <Plus className="w-4 h-4" />
               </Button>

--- a/src/components/pdf-preview-demo.tsx
+++ b/src/components/pdf-preview-demo.tsx
@@ -230,7 +230,8 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
           <div className="flex justify-center space-x-4">
             <Button
               onClick={handleGenerateExamplePDF}
-              className="brick-red brick-red-hover text-white px-6 py-2"
+              variant="brick"
+              className="px-6 py-2"
             >
               <Download className="w-4 h-4 mr-2" />
               Baixar PDF de Exemplo

--- a/src/components/project-call-sheets.tsx
+++ b/src/components/project-call-sheets.tsx
@@ -256,9 +256,9 @@ export function ProjectCallSheets({ project, onBack, onNewCallSheet, onEditCallS
             </p>
           </div>
         </div>
-        <Button 
+        <Button
           onClick={() => onNewCallSheet(project.id!)}
-          className="brick-red brick-red-hover text-white"
+          variant="brick"
         >
           <Plus className="w-4 h-4 mr-2" />
           Nova OD
@@ -270,9 +270,9 @@ export function ProjectCallSheets({ project, onBack, onNewCallSheet, onEditCallS
           <FileText className="w-16 h-16 text-gray-400 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-gray-900 mb-2">Nenhuma ordem do dia criada</h3>
           <p className="text-gray-600 mb-6">Comece criando a primeira ordem do dia para este projeto.</p>
-          <Button 
+          <Button
             onClick={() => onNewCallSheet(project.id!)}
-            className="brick-red brick-red-hover text-white"
+            variant="brick"
           >
             <Plus className="w-4 h-4 mr-2" />
             Criar Primeira OD

--- a/src/components/projects-manager.tsx
+++ b/src/components/projects-manager.tsx
@@ -339,9 +339,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
                 >
                   Cancelar
                 </Button>
-                <Button 
+                <Button
                   onClick={editingProject ? handleUpdateProject : handleCreateProject}
-                  className="brick-red brick-red-hover text-white"
+                  variant="brick"
                   disabled={!newProjectName.trim()}
                 >
                   {editingProject ? 'Atualizar' : 'Criar'}
@@ -357,9 +357,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
           <FolderOpen className="w-16 h-16 text-gray-400 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-gray-900 mb-2">Nenhum projeto criado</h3>
           <p className="text-gray-600 mb-6">Comece criando seu primeiro projeto para organizar suas ordens do dia.</p>
-          <Button 
+          <Button
             onClick={() => setShowNewProjectDialog(true)}
-            className="brick-red brick-red-hover text-white"
+            variant="brick"
           >
             <Plus className="w-4 h-4 mr-2" />
             Criar Primeiro Projeto

--- a/src/components/script-section.tsx
+++ b/src/components/script-section.tsx
@@ -178,7 +178,8 @@ export default function ScriptSection({
                   />
                   <Button
                     asChild
-                    className="brick-red brick-red-hover text-white px-6 py-2 cursor-pointer"
+                    variant="brick"
+                    className="px-6 py-2 cursor-pointer"
                   >
                     <label htmlFor="script-upload">
                       <Upload className="w-4 h-4 mr-2" />
@@ -313,9 +314,9 @@ export default function ScriptSection({
                     >
                       Cancelar
                     </Button>
-                    <Button 
+                    <Button
                       onClick={handleAddAttachment}
-                      className="brick-red brick-red-hover text-white"
+                      variant="brick"
                       disabled={!newAttachmentName.trim() || !newAttachmentUrl.trim()}
                     >
                       Adicionar

--- a/src/components/sync-indicator.tsx
+++ b/src/components/sync-indicator.tsx
@@ -49,11 +49,10 @@ export function SyncIndicator({ lastSync, onForceSync, isLoading }: SyncIndicato
 
       {/* Botão de Sincronização Manual */}
       <Button
-        variant="outline"
+        variant="outlineBrick"
         size="sm"
         onClick={onForceSync}
         disabled={isLoading || !isOnline}
-        className="text-brick-red hover:bg-brick-red hover:text-white"
       >
         <RefreshCw className={`w-4 h-4 mr-1 ${isLoading ? 'animate-spin' : ''}`} />
         Sincronizar

--- a/src/components/template-manager.tsx
+++ b/src/components/template-manager.tsx
@@ -195,7 +195,7 @@ export function TemplateManager({ onSelectTemplate, currentCallSheet }: Template
                 </Button>
                 <Button
                   type="submit"
-                  className="brick-red brick-red-hover text-white"
+                  variant="brick"
                   disabled={createTemplate.isPending}
                 >
                   {createTemplate.isPending ? "Salvando..." : "Salvar Template"}

--- a/src/components/ui/projects-manager.tsx
+++ b/src/components/ui/projects-manager.tsx
@@ -220,9 +220,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
           }
         }}>
           <DialogTrigger asChild>
-            <Button 
+            <Button
               onClick={() => setShowNewProjectDialog(true)}
-              className="brick-red brick-red-hover text-white"
+              variant="brick"
             >
               <Plus className="w-4 h-4 mr-2" />
               Novo Projeto
@@ -294,9 +294,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
                 >
                   Cancelar
                 </Button>
-                <Button 
+                <Button
                   onClick={editingProject ? handleUpdateProject : handleCreateProject}
-                  className="brick-red brick-red-hover text-white"
+                  variant="brick"
                   disabled={!newProjectName.trim()}
                 >
                   {editingProject ? 'Atualizar' : 'Criar'}
@@ -312,9 +312,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
           <FolderOpen className="w-16 h-16 text-gray-400 mx-auto mb-4" />
           <h3 className="text-lg font-medium text-gray-900 mb-2">Nenhum projeto criado</h3>
           <p className="text-gray-600 mb-6">Comece criando seu primeiro projeto para organizar suas ordens do dia.</p>
-          <Button 
+          <Button
             onClick={() => setShowNewProjectDialog(true)}
-            className="brick-red brick-red-hover text-white"
+            variant="brick"
           >
             <Plus className="w-4 h-4 mr-2" />
             Criar Primeiro Projeto


### PR DESCRIPTION
## Summary
- replace brick-red utility classes with `<Button>` variants (`brick`, `outlineBrick`)
- simplify buttons by removing redundant text/hover color classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689105ec3ca0832cae66fa110c1a7a73