### PR TITLE
refactor: unify input styles

### DIFF
--- a/src/components/call-times-section.tsx
+++ b/src/components/call-times-section.tsx
@@ -65,7 +65,7 @@ export default function CallTimesSection({
               type="time"
               value={startTime || ''}
               onChange={(e) => onUpdateField('startTime', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all"
+              size="lg"
             />
           </div>
           <div>
@@ -76,7 +76,7 @@ export default function CallTimesSection({
               type="time"
               value={lunchBreakTime || ''}
               onChange={(e) => onUpdateField('lunchBreakTime', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all"
+              size="lg"
             />
           </div>
           <div>
@@ -87,7 +87,7 @@ export default function CallTimesSection({
               type="time"
               value={endTime || ''}
               onChange={(e) => onUpdateField('endTime', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all"
+              size="lg"
             />
           </div>
         </div>
@@ -165,7 +165,6 @@ export default function CallTimesSection({
                           value={callTime.name}
                           onChange={(e) => onUpdateCrew(callTime.id, { name: e.target.value })}
                           placeholder="Ex: João Silva"
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
                         />
                       </div>
                       <div>
@@ -175,7 +174,6 @@ export default function CallTimesSection({
                           value={callTime.role}
                           onChange={(e) => onUpdateCrew(callTime.id, { role: e.target.value })}
                           placeholder="Ex: Diretor, Cinegrafista"
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
                         />
                       </div>
                       <div>
@@ -185,7 +183,6 @@ export default function CallTimesSection({
                           value={callTime.phone || ''}
                           onChange={(e) => onUpdateCrew(callTime.id, { phone: e.target.value })}
                           placeholder="(11) 99999-9999"
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
                         />
                       </div>
                       <div>
@@ -194,7 +191,6 @@ export default function CallTimesSection({
                           type="time"
                           value={callTime.time}
                           onChange={(e) => onUpdateCrew(callTime.id, { time: e.target.value })}
-                          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
                         />
                       </div>
                     </div>
@@ -233,13 +229,13 @@ export default function CallTimesSection({
                       value={callTime.name}
                       onChange={(e) => onUpdateCast(callTime.id, { name: e.target.value })}
                       placeholder="Nome do Ator/Atriz"
-                      className="w-48 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
+                      className="w-48"
                     />
                     <Input
                       type="time"
                       value={callTime.time}
                       onChange={(e) => onUpdateCast(callTime.id, { time: e.target.value })}
-                      className="w-24 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
+                      className="w-24"
                     />
                     <Button
                       onClick={() => onRemoveCast(callTime.id)}

--- a/src/components/contacts-section.tsx
+++ b/src/components/contacts-section.tsx
@@ -91,7 +91,6 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
             value={contact.name}
             onChange={(e) => onUpdate(contact.id, { name: e.target.value })}
             placeholder="Nome completo"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
           />
         </div>
         <div>
@@ -103,7 +102,6 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
             value={contact.role}
             onChange={(e) => onUpdate(contact.id, { role: e.target.value })}
             placeholder="ex: Diretor, Produtor, etc."
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
           />
         </div>
         <div>
@@ -115,7 +113,6 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
             value={contact.phone}
             onChange={(e) => onUpdate(contact.id, { phone: e.target.value })}
             placeholder="(11) 99999-9999"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
           />
         </div>
       </div>

--- a/src/components/locations-section.tsx
+++ b/src/components/locations-section.tsx
@@ -91,7 +91,6 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
             value={location.address}
             onChange={(e) => onUpdate(location.id, { address: e.target.value })}
             placeholder="Endereço completo da locação"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
           />
         </div>
         <div>
@@ -103,7 +102,6 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
             value={location.notes || ''}
             onChange={(e) => onUpdate(location.id, { notes: e.target.value })}
             placeholder="Informações adicionais"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
           />
         </div>
       </div>

--- a/src/components/production-info.tsx
+++ b/src/components/production-info.tsx
@@ -40,7 +40,7 @@ export default function ProductionInfo({
               value={client}
               onChange={(e) => onUpdateField('client', e.target.value)}
               placeholder="Nome do cliente ou empresa"
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all"
+              size="lg"
             />
           </div>
           <div>
@@ -52,7 +52,7 @@ export default function ProductionInfo({
               value={productionTitle}
               onChange={(e) => onUpdateField('productionTitle', e.target.value)}
               placeholder="Nome do projeto ou filme"
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all"
+              size="lg"
             />
           </div>
           <div>
@@ -63,7 +63,7 @@ export default function ProductionInfo({
               type="date"
               value={shootingDate}
               onChange={(e) => onUpdateField('shootingDate', e.target.value)}
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all"
+              size="lg"
             />
           </div>
           <div>
@@ -75,7 +75,7 @@ export default function ProductionInfo({
               value={producer}
               onChange={(e) => onUpdateField('producer', e.target.value)}
               placeholder="Nome do produtor"
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all"
+              size="lg"
             />
           </div>
           <div>
@@ -87,7 +87,7 @@ export default function ProductionInfo({
               value={director}
               onChange={(e) => onUpdateField('director', e.target.value)}
               placeholder="Nome do diretor"
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all"
+              size="lg"
             />
           </div>
         </div>

--- a/src/components/scenes-section.tsx
+++ b/src/components/scenes-section.tsx
@@ -92,7 +92,6 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
             value={scene.number}
             onChange={(e) => onUpdate(scene.id, { number: e.target.value })}
             placeholder="Ex: 1A, 2B, 15"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
           />
         </div>
         <div className="md:col-span-2">
@@ -104,7 +103,6 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
             value={scene.description}
             onChange={(e) => onUpdate(scene.id, { description: e.target.value })}
             placeholder="Breve descrição da cena"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
           />
         </div>
         <div>
@@ -116,7 +114,6 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
             value={scene.estimatedTime || ''}
             onChange={(e) => onUpdate(scene.id, { estimatedTime: e.target.value })}
             placeholder="Ex: 2h, 30min"
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
           />
         </div>
       </div>
@@ -128,7 +125,7 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
           value={scene.cast}
           onChange={(e) => onUpdate(scene.id, { cast: e.target.value })}
           placeholder="Liste os atores necessários para esta cena"
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm h-20 resize-none"
+          className="h-20 resize-none"
         />
       </div>
     </div>

--- a/src/components/script-section.tsx
+++ b/src/components/script-section.tsx
@@ -196,7 +196,6 @@ export default function ScriptSection({
                     placeholder="Cole o link do roteiro (Google Drive, Dropbox, etc.)"
                     value={scriptUrl}
                     onChange={(e) => handleUrlInput(e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
                   />
                 </div>
               </div>
@@ -219,7 +218,6 @@ export default function ScriptSection({
               value={scriptName}
               onChange={(e) => onUpdateField('scriptName', e.target.value)}
               placeholder="Ex: Roteiro Final v3.0, Script - Cena Externa"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
             />
           </div>
         )}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,16 +1,33 @@
 import * as React from "react"
 
+import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+const inputVariants = cva(
+  "w-full border border-gray-300 bg-background focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      size: {
+        default: "px-3 py-2 rounded-md text-sm",
+        lg: "px-4 py-3 rounded-lg text-base",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+)
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, size, type, ...props }, ref) => {
     return (
       <input
         type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          className
-        )}
+        className={cn(inputVariants({ size, className }))}
         ref={ref}
         {...props}
       />
@@ -19,4 +36,4 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
 )
 Input.displayName = "Input"
 
-export { Input }
+export { Input, inputVariants }

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,22 +1,38 @@
 import * as React from "react"
 
+import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
-const Textarea = React.forwardRef<
-  HTMLTextAreaElement,
-  React.ComponentProps<"textarea">
->(({ className, ...props }, ref) => {
-  return (
-    <textarea
-      className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        className
-      )}
-      ref={ref}
-      {...props}
-    />
-  )
-})
+const textareaVariants = cva(
+  "w-full border border-gray-300 bg-background focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      size: {
+        default: "min-h-[80px] px-3 py-2 rounded-md text-sm",
+        lg: "px-4 py-3 rounded-lg text-base",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+)
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    VariantProps<typeof textareaVariants> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, size, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(textareaVariants({ size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
 Textarea.displayName = "Textarea"
 
-export { Textarea }
+export { Textarea, textareaVariants }

--- a/src/pages/call-sheet-generator.tsx
+++ b/src/pages/call-sheet-generator.tsx
@@ -417,7 +417,8 @@ export default function CallSheetGenerator() {
               value={callSheet.generalNotes}
               onChange={(e) => updateField('generalNotes', e.target.value)}
               placeholder="Informações importantes para toda a equipe: condições climáticas, equipamentos especiais, restrições de acesso, contatos de emergência, etc."
-              className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all h-32 resize-none"
+              size="lg"
+              className="h-32 resize-none"
             />
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- add size variants to Input and Textarea components
- consolidate repeated inline classes in call sheet sections

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68910d665748832c9c27a0859d3af167