### PR TITLE
refactor: unify select components

### DIFF
--- a/src/components/script-section.tsx
+++ b/src/components/script-section.tsx
@@ -4,6 +4,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 import type { Attachment } from "@shared/schema";
 import { useState } from "react";
@@ -255,19 +262,22 @@ export default function ScriptSection({
                     <Label htmlFor="attachment-type" className="text-sm font-medium">
                       Tipo de Arquivo
                     </Label>
-                    <select
-                      id="attachment-type"
+                    <Select
                       value={newAttachmentType}
-                      onChange={(e) => setNewAttachmentType(e.target.value)}
-                      className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent text-sm"
+                      onValueChange={setNewAttachmentType}
                     >
-                      <option value="documento">Documento</option>
-                      <option value="imagem">Imagem</option>
-                      <option value="vídeo">Vídeo</option>
-                      <option value="áudio">Áudio</option>
-                      <option value="planilha">Planilha</option>
-                      <option value="apresentação">Apresentação</option>
-                    </select>
+                      <SelectTrigger id="attachment-type" className="mt-1">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="documento">Documento</SelectItem>
+                        <SelectItem value="imagem">Imagem</SelectItem>
+                        <SelectItem value="vídeo">Vídeo</SelectItem>
+                        <SelectItem value="áudio">Áudio</SelectItem>
+                        <SelectItem value="planilha">Planilha</SelectItem>
+                        <SelectItem value="apresentação">Apresentação</SelectItem>
+                      </SelectContent>
+                    </Select>
                   </div>
 
                   <div>

--- a/src/pages/call-sheet-generator.tsx
+++ b/src/pages/call-sheet-generator.tsx
@@ -8,6 +8,13 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
 
 import { useToast } from "@/hooks/use-toast";
 import { useCallSheet } from "@/hooks/use-call-sheet";
@@ -474,18 +481,21 @@ export default function CallSheetGenerator() {
                 </div>
                 <div>
                   <Label htmlFor="template-category">Categoria</Label>
-                  <select
-                    id="template-category"
+                  <Select
                     value={templateCategory}
-                    onChange={(e) => setTemplateCategory(e.target.value)}
-                    className="mt-1 w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-brick-red focus:border-transparent"
+                    onValueChange={setTemplateCategory}
                   >
-                    <option value="produção">Produção</option>
-                    <option value="comercial">Comercial</option>
-                    <option value="documentário">Documentário</option>
-                    <option value="evento">Evento</option>
-                    <option value="outros">Outros</option>
-                  </select>
+                    <SelectTrigger id="template-category" className="mt-1">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="produção">Produção</SelectItem>
+                      <SelectItem value="comercial">Comercial</SelectItem>
+                      <SelectItem value="documentário">Documentário</SelectItem>
+                      <SelectItem value="evento">Evento</SelectItem>
+                      <SelectItem value="outros">Outros</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
                 <div className="flex justify-end gap-2 pt-4">
                   <Button


### PR DESCRIPTION
## Summary
- replace attachment type and template category selects with shared `<Select>` component
- drop redundant utility classes after component migration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689119e1c0ac832c9bafd0c258aca7fa