### PR TITLE
feat: add ghostBrick button variant

### DIFF
--- a/src/components/brick-header.tsx
+++ b/src/components/brick-header.tsx
@@ -37,18 +37,15 @@ export default function BrickHeader({ onExportPDF, onSave, hasUnsavedChanges }: 
               Gerar PDF
             </Button>
             <Link href="/team-members">
-              <Button
-                variant="ghost"
-                className="text-gray-300 hover:text-white hover:bg-[var(--brick-red)] transition-colors"
-              >
+              <Button variant="ghostBrick">
                 <Users className="w-4 h-4 mr-2" />
                 Membros da equipe
               </Button>
             </Link>
             <Button
               onClick={onSave}
-              variant="ghost"
-              className={`${hasUnsavedChanges ? 'text-yellow-400' : 'text-gray-300'} hover:text-white hover:bg-[var(--brick-red)] transition-colors`}
+              variant="ghostBrick"
+              className={hasUnsavedChanges ? 'text-yellow-400' : undefined}
             >
               <Save className="w-4 h-4 mr-2" />
               Salvar OD

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,6 +17,8 @@ const buttonVariants = cva(
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghostBrick:
+          "text-gray-300 hover:text-white hover:bg-[var(--brick-red)]",
         iconGhost: "hover:bg-transparent",
         link: "text-primary underline-offset-4 hover:underline",
         brick:


### PR DESCRIPTION
## Summary
- add `ghostBrick` button variant with built-in Brick hover color
- replace inline hover styles in header buttons with the new variant

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68911b869c64832ca11ab5261b8deefb