### PR TITLE
refactor: use brick-red CSS variable

### DIFF
--- a/src/components/call-sheet-history.tsx
+++ b/src/components/call-sheet-history.tsx
@@ -68,7 +68,7 @@ export function CallSheetHistory({ onSelectCallSheet }: CallSheetHistoryProps) {
     return (
       <div className="flex items-center justify-center py-8">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brick-red mx-auto mb-4"></div>
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[var(--brick-red)] mx-auto mb-4"></div>
           <p className="text-gray-500">Carregando histórico...</p>
         </div>
       </div>

--- a/src/components/call-times-section.tsx
+++ b/src/components/call-times-section.tsx
@@ -97,7 +97,7 @@ export default function CallTimesSection({
           <div className="border border-gray-200 rounded-lg p-4">
             <div className="flex justify-between items-center mb-4">
               <h3 className="font-medium text-gray-900 flex items-center">
-                <Users className="w-4 h-4 mr-2 text-brick-red" />
+                <Users className="w-4 h-4 mr-2 text-[var(--brick-red)]" />
                 Equipe Técnica
               </h3>
               <Button
@@ -204,7 +204,7 @@ export default function CallTimesSection({
           <div className="border border-gray-200 rounded-lg p-4">
             <div className="flex justify-between items-center mb-4">
               <h3 className="font-medium text-gray-900 flex items-center">
-                <Star className="w-4 h-4 mr-2 text-brick-red" />
+                <Star className="w-4 h-4 mr-2 text-[var(--brick-red)]" />
                 Elenco
               </h3>
               <Button

--- a/src/components/projects-manager.tsx
+++ b/src/components/projects-manager.tsx
@@ -154,7 +154,7 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
         <CardHeader className="pb-3">
           <div className="flex items-start justify-between">
             <div className="flex items-center space-x-3">
-              <div className="w-10 h-10 brick-red rounded-lg flex items-center justify-center">
+              <div className="w-10 h-10 bg-[var(--brick-red)] rounded-lg flex items-center justify-center">
                 <FolderOpen className="w-5 h-5 text-white" />
               </div>
               <div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -24,7 +24,7 @@ const buttonVariants = cva(
         brick:
           "bg-[var(--brick-red)] text-white hover:bg-[var(--brick-red-hover)] hover:text-white",
         outlineBrick:
-          "border border-brick-red bg-background text-brick-red hover:bg-[var(--brick-red)] hover:text-white",
+          "border border-[var(--brick-red)] bg-background text-[var(--brick-red)] hover:bg-[var(--brick-red)] hover:text-white",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const inputVariants = cva(
-  "w-full border border-gray-300 bg-background focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+  "w-full border border-gray-300 bg-background focus:ring-2 focus:ring-[var(--brick-red)] focus:border-transparent transition-all placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       size: {

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const textareaVariants = cva(
-  "w-full border border-gray-300 bg-background focus:ring-2 focus:ring-brick-red focus:border-transparent transition-all placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+  "w-full border border-gray-300 bg-background focus:ring-2 focus:ring-[var(--brick-red)] focus:border-transparent transition-all placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
   {
     variants: {
       size: {

--- a/src/index.css
+++ b/src/index.css
@@ -83,19 +83,6 @@
     background-color: var(--brick-light);
   }
   
-  .brick-red {
-    background-color: var(--brick-red);
-  }
-
-  /* Utility for hover background on outline buttons */
-  .hover\:bg-brick-red:hover {
-    background-color: var(--brick-red);
-  }
-  
-  .brick-red-hover:hover {
-    background-color: var(--brick-red-hover);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.25);
-  }
   
   .text-brick-black {
     color: var(--brick-black);
@@ -105,17 +92,6 @@
     color: var(--brick-dark);
   }
   
-  .text-brick-red {
-    color: var(--brick-red);
-  }
-  
-  .border-brick-red {
-    border-color: var(--brick-red);
-  }
-  
-  .focus\:ring-brick-red:focus {
-    --tw-ring-color: var(--brick-red);
-  }
   
   /* Dialog overlay custom styles */
   .dialog-overlay-light {


### PR DESCRIPTION
## Summary
- replace brick-red utility classes with CSS variable tokens
- drop unused brick-red utilities from global stylesheet

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68911ca75314832ca01b7867a6dc3153