### PR TITLE
Use destructive icon variant for delete buttons

### DIFF
--- a/src/components/call-times-section.tsx
+++ b/src/components/call-times-section.tsx
@@ -150,9 +150,8 @@ export default function CallTimesSection({
                       </div>
                       <Button
                         onClick={() => onRemoveCrew(callTime.id)}
-                        variant="iconGhost"
+                        variant="iconDestructive"
                         size="sm"
-                        className="text-gray-400 hover:text-red-500 transition-colors"
                       >
                         <Minus className="w-4 h-4" />
                       </Button>
@@ -239,9 +238,8 @@ export default function CallTimesSection({
                     />
                     <Button
                       onClick={() => onRemoveCast(callTime.id)}
-                      variant="iconGhost"
+                      variant="iconDestructive"
                       size="sm"
-                      className="text-gray-400 hover:text-red-500 transition-colors"
                     >
                       <Minus className="w-4 h-4" />
                     </Button>

--- a/src/components/contacts-section.tsx
+++ b/src/components/contacts-section.tsx
@@ -74,9 +74,8 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
         </div>
         <Button
           onClick={() => onRemove(contact.id)}
-          variant="iconGhost"
+          variant="iconDestructive"
           size="sm"
-          className="text-gray-400 hover:text-red-500 transition-colors"
         >
           <Trash2 className="w-4 h-4" />
         </Button>

--- a/src/components/locations-section.tsx
+++ b/src/components/locations-section.tsx
@@ -74,9 +74,8 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
         </div>
         <Button
           onClick={() => onRemove(location.id)}
-          variant="iconGhost"
+          variant="iconDestructive"
           size="sm"
-          className="text-gray-400 hover:text-red-500 transition-colors"
         >
           <Trash2 className="w-4 h-4" />
         </Button>

--- a/src/components/scenes-section.tsx
+++ b/src/components/scenes-section.tsx
@@ -75,9 +75,8 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
         </div>
         <Button
           onClick={() => onRemove(scene.id)}
-          variant="iconGhost"
+          variant="iconDestructive"
           size="sm"
-          className="text-gray-400 hover:text-red-500 transition-colors"
         >
           <Trash2 className="w-4 h-4" />
         </Button>

--- a/src/components/template-manager.tsx
+++ b/src/components/template-manager.tsx
@@ -253,9 +253,9 @@ export function TemplateManager({ onSelectTemplate, currentCallSheet }: Template
                     </Badge>
                   </div>
                   <Button
-                    variant="iconGhost"
+                    variant="iconDestructive"
                     size="sm"
-                    className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-400 hover:text-red-500"
+                    className="opacity-0 group-hover:opacity-100 transition-opacity"
                     onClick={() => handleDeleteTemplate(template.id, template.name)}
                   >
                     <Trash2 className="w-4 h-4" />


### PR DESCRIPTION
## Summary
- replace delete buttons with `iconDestructive` variant
- drop explicit red hover classes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689121d15160832c829ef7456320d746