### PR TITLE
refactor: use CSS variables for brick colors

### DIFF
--- a/src/components/call-sheet-history.tsx
+++ b/src/components/call-sheet-history.tsx
@@ -95,7 +95,7 @@ export function CallSheetHistory({ onSelectCallSheet }: CallSheetHistoryProps) {
             <CardHeader className="pb-3">
               <div className="flex justify-between items-start">
                 <div className="flex-1">
-                  <CardTitle className="text-lg text-brick-dark flex items-center gap-2">
+                  <CardTitle className="text-lg text-[var(--brick-dark)] flex items-center gap-2">
                     <FileText className="w-5 h-5" />
                     {callSheet.productionTitle || "Sem título"}
                   </CardTitle>

--- a/src/components/call-times-section.tsx
+++ b/src/components/call-times-section.tsx
@@ -48,10 +48,10 @@ export default function CallTimesSection({
       <CardContent className="p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center">
-            <div className="w-8 h-8 brick-dark rounded-lg flex items-center justify-center mr-3">
+            <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
               <Clock className="text-white w-4 h-4" />
             </div>
-            <h2 className="text-xl font-semibold text-brick-dark">Horários de Chamada</h2>
+            <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Horários de Chamada</h2>
           </div>
         </div>
 

--- a/src/components/contacts-section.tsx
+++ b/src/components/contacts-section.tsx
@@ -150,10 +150,10 @@ export default function ContactsSection({
       <CardContent className="p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center">
-            <div className="w-8 h-8 brick-dark rounded-lg flex items-center justify-center mr-3">
+            <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
               <Users className="text-white w-4 h-4" />
             </div>
-            <h2 className="text-xl font-semibold text-brick-dark">Contatos Importantes</h2>
+            <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Contatos Importantes</h2>
           </div>
           <Button
             onClick={onAdd}

--- a/src/components/locations-section.tsx
+++ b/src/components/locations-section.tsx
@@ -138,10 +138,10 @@ export default function LocationsSection({
       <CardContent className="p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center">
-            <div className="w-8 h-8 brick-dark rounded-lg flex items-center justify-center mr-3">
+            <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
               <MapPin className="text-white w-4 h-4" />
             </div>
-            <h2 className="text-xl font-semibold text-brick-dark">Locações</h2>
+            <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Locações</h2>
           </div>
           <Button
             onClick={onAdd}

--- a/src/components/pdf-preview-demo.tsx
+++ b/src/components/pdf-preview-demo.tsx
@@ -100,7 +100,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
 
   return (
     <Card className="max-w-4xl mx-auto my-8">
-      <CardHeader className="brick-dark text-white">
+      <CardHeader className="bg-[var(--brick-dark)] text-white">
         <CardTitle className="flex items-center">
           <FileText className="w-6 h-6 mr-3" />
           Demonstração do PDF Gerado
@@ -114,7 +114,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
             <div className="brick-black text-white p-4 flex justify-between items-center">
               <div className="flex items-center space-x-4">
                 <div className="w-12 h-8 bg-white flex items-center justify-center">
-                  <span className="text-brick-black font-bold text-xs">BRICK</span>
+                  <span className="text-[var(--brick-black)] font-bold text-xs">BRICK</span>
                 </div>
                 <div>
                   <h2 className="text-lg font-bold">MAPA DE FILMAGEM</h2>
@@ -130,7 +130,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
             <div className="bg-white p-6 space-y-6 text-sm">
               {/* Production Info */}
               <section>
-                <h3 className="font-bold text-base mb-3 text-brick-dark">INFORMAÇÕES DA PRODUÇÃO</h3>
+                <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">INFORMAÇÕES DA PRODUÇÃO</h3>
                 <div className="space-y-1 text-gray-700">
                   <p><strong>Título:</strong> Curta-Metragem Brick - Projeto Exemplo</p>
                   <p><strong>Data de Filmagem:</strong> 15/02/2025</p>
@@ -141,7 +141,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
 
               {/* Locations */}
               <section>
-                <h3 className="font-bold text-base mb-3 text-brick-dark">LOCAÇÕES</h3>
+                <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">LOCAÇÕES</h3>
                 <div className="space-y-3 text-gray-700">
                   <div>
                     <p className="font-semibold">Locação 1:</p>
@@ -158,7 +158,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
 
               {/* Scenes */}
               <section>
-                <h3 className="font-bold text-base mb-3 text-brick-dark">CENAS PROGRAMADAS</h3>
+                <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">CENAS PROGRAMADAS</h3>
                 <div className="space-y-3 text-gray-700">
                   <div>
                     <p className="font-semibold">Cena 1A:</p>
@@ -175,7 +175,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
 
               {/* Call Times */}
               <section>
-                <h3 className="font-bold text-base mb-3 text-brick-dark">HORÁRIOS DE CHAMADA</h3>
+                <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">HORÁRIOS DE CHAMADA</h3>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-gray-700">
                   <div>
                     <p className="font-semibold mb-2">Equipe Técnica:</p>
@@ -197,7 +197,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
 
               {/* General Notes */}
               <section>
-                <h3 className="font-bold text-base mb-3 text-brick-dark">OBSERVAÇÕES GERAIS</h3>
+                <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">OBSERVAÇÕES GERAIS</h3>
                 <div className="text-gray-700">
                   <p>ATENÇÃO: Previsão de chuva pela manhã. Equipamento de proteção disponível no caminhão de produção. Catering será servido às 12h no local...</p>
                 </div>
@@ -205,7 +205,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
 
               {/* Contacts */}
               <section>
-                <h3 className="font-bold text-base mb-3 text-brick-dark">CONTATOS IMPORTANTES</h3>
+                <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">CONTATOS IMPORTANTES</h3>
                 <div className="space-y-2 text-gray-700">
                   <div>
                     <p>Maria Produtora - Produtora Executiva</p>

--- a/src/components/production-info.tsx
+++ b/src/components/production-info.tsx
@@ -24,10 +24,10 @@ export default function ProductionInfo({
     <Card className="mb-8">
       <CardContent className="p-6">
         <div className="flex items-center mb-6">
-          <div className="w-8 h-8 brick-dark rounded-lg flex items-center justify-center mr-3">
+          <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
             <Film className="text-white w-4 h-4" />
           </div>
-          <h2 className="text-xl font-semibold text-brick-dark">Informações da Produção</h2>
+          <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Informações da Produção</h2>
         </div>
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/src/components/project-call-sheets.tsx
+++ b/src/components/project-call-sheets.tsx
@@ -151,7 +151,7 @@ export function ProjectCallSheets({ project, onBack, onNewCallSheet, onEditCallS
               <FileText className="w-5 h-5 text-blue-600" />
             </div>
             <div>
-              <CardTitle className="text-lg text-brick-dark">{callSheet.productionTitle}</CardTitle>
+              <CardTitle className="text-lg text-[var(--brick-dark)]">{callSheet.productionTitle}</CardTitle>
               <p className="text-sm text-gray-600 flex items-center mt-1">
                 <Calendar className="w-3 h-3 mr-1" />
                 {new Date(callSheet.shootingDate).toLocaleDateString('pt-BR')}
@@ -250,7 +250,7 @@ export function ProjectCallSheets({ project, onBack, onNewCallSheet, onEditCallS
             <ArrowLeft className="w-4 h-4" />
           </Button>
           <div>
-            <h2 className="text-2xl font-bold text-brick-dark">{project.name}</h2>
+            <h2 className="text-2xl font-bold text-[var(--brick-dark)]">{project.name}</h2>
             <p className="text-gray-600">
               {callSheets.length} ordem{callSheets.length !== 1 ? 's' : ''} do dia
             </p>

--- a/src/components/projects-manager.tsx
+++ b/src/components/projects-manager.tsx
@@ -158,7 +158,7 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
                 <FolderOpen className="w-5 h-5 text-white" />
               </div>
               <div>
-                <CardTitle className="text-lg text-brick-dark">{project.name}</CardTitle>
+                <CardTitle className="text-lg text-[var(--brick-dark)]">{project.name}</CardTitle>
                 {project.client && (
                   <p className="text-sm text-gray-600 flex items-center mt-1">
                     <User className="w-3 h-3 mr-1" />
@@ -245,7 +245,7 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-brick-dark">Projetos</h2>
+          <h2 className="text-2xl font-bold text-[var(--brick-dark)]">Projetos</h2>
           <p className="text-gray-600">Organize suas ordens do dia por projeto</p>
           <div className="mt-2">
             <SyncIndicator 

--- a/src/components/scenes-section.tsx
+++ b/src/components/scenes-section.tsx
@@ -161,10 +161,10 @@ export default function ScenesSection({
       <CardContent className="p-6">
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center">
-            <div className="w-8 h-8 brick-dark rounded-lg flex items-center justify-center mr-3">
+            <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
               <Video className="text-white w-4 h-4" />
             </div>
-            <h2 className="text-xl font-semibold text-brick-dark">Cenas Programadas</h2>
+            <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Cenas Programadas</h2>
           </div>
           <Button
             onClick={onAdd}

--- a/src/components/script-section.tsx
+++ b/src/components/script-section.tsx
@@ -127,10 +127,10 @@ export default function ScriptSection({
     <Card className="mb-8">
       <CardContent className="p-6">
         <div className="flex items-center mb-6">
-          <div className="w-8 h-8 brick-dark rounded-lg flex items-center justify-center mr-3">
+          <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
             <FileText className="text-white w-4 h-4" />
           </div>
-          <h2 className="text-xl font-semibold text-brick-dark">Roteiro</h2>
+          <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Roteiro</h2>
         </div>
 
         {scriptUrl ? (

--- a/src/index.css
+++ b/src/index.css
@@ -70,29 +70,11 @@
   .brick-black {
     background-color: var(--brick-black);
   }
-  
-  .brick-dark {
-    background-color: var(--brick-dark);
-  }
-  
+
   .brick-gray {
     background-color: var(--brick-gray);
   }
-  
-  .brick-light {
-    background-color: var(--brick-light);
-  }
-  
-  
-  .text-brick-black {
-    color: var(--brick-black);
-  }
-  
-  .text-brick-dark {
-    color: var(--brick-dark);
-  }
-  
-  
+
   /* Dialog overlay custom styles */
   .dialog-overlay-light {
     background-color: rgba(0, 0, 0, 0.1);

--- a/src/pages/call-sheet-generator.tsx
+++ b/src/pages/call-sheet-generator.tsx
@@ -284,7 +284,7 @@ export default function CallSheetGenerator() {
 
   if (showPreview) {
     return (
-      <div className="min-h-screen brick-light font-inter text-brick-dark">
+      <div className="min-h-screen bg-[var(--brick-light)] font-inter text-[var(--brick-dark)]">
         <BrickHeader 
           onExportPDF={handleExportPDF}
           onSave={handleSave}
@@ -299,7 +299,7 @@ export default function CallSheetGenerator() {
   }
 
   return (
-    <div className="min-h-screen brick-light font-inter text-brick-dark">
+    <div className="min-h-screen bg-[var(--brick-light)] font-inter text-[var(--brick-dark)]">
       <BrickHeader 
         onExportPDF={handleExportPDF}
         onSave={handleSave}
@@ -414,10 +414,10 @@ export default function CallSheetGenerator() {
         <Card className="mb-8">
           <CardContent className="p-6">
             <div className="flex items-center mb-6">
-              <div className="w-8 h-8 brick-dark rounded-lg flex items-center justify-center mr-3">
+              <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
                 <StickyNote className="text-white w-4 h-4" />
               </div>
-              <h2 className="text-xl font-semibold text-brick-dark">Observações Gerais</h2>
+              <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Observações Gerais</h2>
             </div>
             
             <Textarea

--- a/src/pages/team-members.tsx
+++ b/src/pages/team-members.tsx
@@ -151,7 +151,7 @@ export default function TeamMembers() {
   };
 
   return (
-    <div className="min-h-screen brick-light font-inter text-brick-dark">
+    <div className="min-h-screen bg-[var(--brick-light)] font-inter text-[var(--brick-dark)]">
       <BrickHeader
         onExportPDF={() => {}}
         onSave={() => {}}


### PR DESCRIPTION
## Summary
- replace `brick-dark`, `brick-light`, and related text classes with CSS variable-based Tailwind utilities
- drop obsolete color utility definitions from `index.css`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6891237f7ef0832c9cf7c2432983943f