### PR TITLE
feat: add destructive variant to dropdown menu

### DIFF
--- a/src/components/project-call-sheets.tsx
+++ b/src/components/project-call-sheets.tsx
@@ -195,9 +195,9 @@ export function ProjectCallSheets({ project, onBack, onNewCallSheet, onEditCallS
                     Voltar para Rascunho
                   </DropdownMenuItem>
                 )}
-                <DropdownMenuItem 
+                <DropdownMenuItem
                   onClick={() => setShowDeleteDialog(callSheet)}
-                  className="text-red-600"
+                  variant="destructive"
                 >
                   <Trash2 className="w-4 h-4 mr-2" />
                   Excluir

--- a/src/components/projects-manager.tsx
+++ b/src/components/projects-manager.tsx
@@ -200,9 +200,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
                     <Archive className="w-4 h-4 mr-2" />
                     Concluir
                   </DropdownMenuItem>
-                  <DropdownMenuItem 
+                  <DropdownMenuItem
                     onClick={(e) => { e.stopPropagation(); handleDeleteProject(project); }}
-                    className="text-red-600"
+                    variant="destructive"
                   >
                     <Trash2 className="w-4 h-4 mr-2" />
                     Excluir

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -3,6 +3,7 @@ import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { cva, type VariantProps } from "class-variance-authority"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -72,18 +73,32 @@ const DropdownMenuContent = React.forwardRef<
 ))
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
 
+const dropdownMenuItemVariants = cva(
+  "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "focus:bg-accent focus:text-accent-foreground",
+        destructive:
+          "text-destructive focus:bg-destructive focus:text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean
-  }
->(({ className, inset, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> &
+    VariantProps<typeof dropdownMenuItemVariants> & { inset?: boolean }
+>(({ className, inset, variant, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
-      inset && "pl-8",
-      className
+      dropdownMenuItemVariants({ variant, className }),
+      inset && "pl-8"
     )}
     {...props}
   />


### PR DESCRIPTION
## Summary
- allow dropdown menu items to use a `destructive` variant with red text and focus states
- swap hardcoded red text styles for `variant="destructive"` on project and call sheet actions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68912676d80c832ca0828c5906ad2606