### PR TITLE
refactor: replace hardcoded colors with theme classes

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -52,7 +52,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_]:stroke-border [&_.recharts-sector]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
         {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -81,9 +81,7 @@
   }
   
   .dialog-content-enhanced {
-    background-color: white;
-    border: 1px solid #e5e5e5;
-    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+    @apply bg-background border border-border shadow-2xl;
   }
   
   /* Force high z-index for dialogs */

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -18,7 +18,7 @@
   transform: translate(-50%, -50%) !important;
   max-width: 90vw !important;
   max-height: 90vh !important;
-  background: white !important;
+  background: var(--background) !important;
   border-radius: 8px !important;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05) !important;
 }
@@ -35,8 +35,8 @@
 
 .dialog-create-project [data-radix-dialog-content] {
   z-index: 9999 !important;
-  background: white !important;
-  border: 1px solid #e5e7eb !important;
+  background: var(--background) !important;
+  border: 1px solid var(--border) !important;
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25) !important;
 }
 
@@ -45,7 +45,7 @@
 .dialog-create-project textarea {
   position: relative !important;
   z-index: 10000 !important;
-  background: white !important;
+  background: var(--background) !important;
 }
 
 /* Correção para botões */


### PR DESCRIPTION
## Summary
- replace inline dialog styles with Tailwind utility classes
- apply theme variables to dialog styles
- clean up chart component selectors to avoid hard-coded color codes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68912ef89e10832ca17743c003d644cb