### PR TITLE
refactor: unify dialog z-index

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,10 +19,9 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-[9998] bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
-    style={{ zIndex: 9998 }}
     {...props}
   />
 ))
@@ -32,31 +31,24 @@ const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 >(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-[9999] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
-        className
-      )}
-      style={{
-        zIndex: 9999,
-        position: 'fixed',
-        top: '50%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)'
-      }}
-      {...props}
-    >
-      {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Fechar</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-))
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-[60] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Fechar</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  ))
 DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,8 @@
   --brick-light: hsl(0, 0%, 98%);
   --brick-red: hsl(0, 79%, 43%);
   --brick-red-hover: hsl(0, 84%, 38%);
+  --z-dialog-overlay: 50;
+  --z-dialog-content: 60;
 }
 
 .dark {
@@ -86,10 +88,10 @@
   
   /* Force high z-index for dialogs */
   [data-radix-dialog-overlay] {
-    z-index: 9999 !important;
+    z-index: var(--z-dialog-overlay);
   }
-  
+
   [data-radix-dialog-content] {
-    z-index: 10000 !important;
+    z-index: var(--z-dialog-content);
   }
 }

--- a/src/styles/dialog.css
+++ b/src/styles/dialog.css
@@ -1,17 +1,17 @@
 /* Correções específicas para modais no Netlify */
 [data-radix-popper-content-wrapper] {
-  z-index: 10000 !important;
+  z-index: var(--z-dialog-content);
 }
 
 [data-state="open"][data-radix-dialog-overlay] {
-  z-index: 9998 !important;
+  z-index: var(--z-dialog-overlay);
   position: fixed !important;
   inset: 0 !important;
   background-color: rgba(0, 0, 0, 0.5) !important;
 }
 
 [data-state="open"][data-radix-dialog-content] {
-  z-index: 9999 !important;
+  z-index: var(--z-dialog-content);
   position: fixed !important;
   top: 50% !important;
   left: 50% !important;
@@ -25,16 +25,16 @@
 
 /* Correção específica para o modal de criação de projeto */
 .dialog-create-project {
-  z-index: 10000 !important;
+  z-index: var(--z-dialog-content);
 }
 
 .dialog-create-project [data-radix-dialog-overlay] {
-  z-index: 9998 !important;
+  z-index: var(--z-dialog-overlay);
   background: rgba(0, 0, 0, 0.6) !important;
 }
 
 .dialog-create-project [data-radix-dialog-content] {
-  z-index: 9999 !important;
+  z-index: var(--z-dialog-content);
   background: var(--background) !important;
   border: 1px solid var(--border) !important;
   box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25) !important;
@@ -44,14 +44,14 @@
 .dialog-create-project input,
 .dialog-create-project textarea {
   position: relative !important;
-  z-index: 10000 !important;
+  z-index: var(--z-dialog-content);
   background: var(--background) !important;
 }
 
 /* Correção para botões */
 .dialog-create-project button {
   position: relative !important;
-  z-index: 10000 !important;
+  z-index: var(--z-dialog-content);
 }
 
 /* Prevent body scroll when modal is open */


### PR DESCRIPTION
## Summary
- define global z-index variables for dialog overlay and content
- replace hardcoded z-indexes in dialog styles with variables
- use Tailwind classes for overlay/content z-index and remove inline styles

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68913203a398832c9cc23ef65af3604c