### PR TITLE
refactor: replace white backgrounds with tokens

### DIFF
--- a/src/components/contacts-section.tsx
+++ b/src/components/contacts-section.tsx
@@ -59,18 +59,18 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
     <div
       ref={setNodeRef}
       style={style}
-      className={`border border-gray-200 rounded-lg p-4 bg-white ${isDragging ? 'shadow-lg' : ''}`}
+      className={`border border-gray-200 rounded-lg p-4 bg-card ${isDragging ? 'shadow-lg' : ''}`}
     >
       <div className="flex justify-between items-start mb-3">
         <div className="flex items-center gap-2">
           <div
             {...attributes}
             {...listeners}
-            className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 p-1"
+            className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground p-1"
           >
             <GripVertical className="w-4 h-4" />
           </div>
-          <h3 className="font-medium text-gray-900">Contato #{index + 1}</h3>
+          <h3 className="font-medium text-foreground">Contato #{index + 1}</h3>
         </div>
         <Button
           onClick={() => onRemove(contact.id)}
@@ -82,7 +82,7 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
       </div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
-          <Label className="block text-sm font-medium text-gray-600 mb-1">
+          <Label className="block text-sm font-medium text-muted-foreground mb-1">
             Nome
           </Label>
           <Input
@@ -93,7 +93,7 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
           />
         </div>
         <div>
-          <Label className="block text-sm font-medium text-gray-600 mb-1">
+          <Label className="block text-sm font-medium text-muted-foreground mb-1">
             Cargo/Função
           </Label>
           <Input
@@ -104,7 +104,7 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
           />
         </div>
         <div>
-          <Label className="block text-sm font-medium text-gray-600 mb-1">
+          <Label className="block text-sm font-medium text-muted-foreground mb-1">
             Telefone
           </Label>
           <Input
@@ -166,7 +166,7 @@ export default function ContactsSection({
         </div>
 
         {contacts.length === 0 ? (
-          <div className="text-center py-8 text-gray-500 italic">
+          <div className="text-center py-8 text-muted-foreground italic">
             Clique em "Novo Contato" para adicionar contatos importantes
           </div>
         ) : (

--- a/src/components/locations-section.tsx
+++ b/src/components/locations-section.tsx
@@ -59,18 +59,18 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
     <div
       ref={setNodeRef}
       style={style}
-      className={`border border-gray-200 rounded-lg p-4 bg-white ${isDragging ? 'shadow-lg' : ''}`}
+      className={`border border-gray-200 rounded-lg p-4 bg-card ${isDragging ? 'shadow-lg' : ''}`}
     >
       <div className="flex justify-between items-start mb-3">
         <div className="flex items-center gap-2">
           <div
             {...attributes}
             {...listeners}
-            className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 p-1"
+            className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground p-1"
           >
             <GripVertical className="w-4 h-4" />
           </div>
-          <h3 className="font-medium text-gray-900">Locação #{index + 1}</h3>
+          <h3 className="font-medium text-foreground">Locação #{index + 1}</h3>
         </div>
         <Button
           onClick={() => onRemove(location.id)}
@@ -82,7 +82,7 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <Label className="block text-sm font-medium text-gray-600 mb-1">
+          <Label className="block text-sm font-medium text-muted-foreground mb-1">
             Endereço
           </Label>
           <Input
@@ -93,7 +93,7 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
           />
         </div>
         <div>
-          <Label className="block text-sm font-medium text-gray-600 mb-1">
+          <Label className="block text-sm font-medium text-muted-foreground mb-1">
             Observações
           </Label>
           <Input
@@ -154,7 +154,7 @@ export default function LocationsSection({
         </div>
 
         {locations.length === 0 ? (
-          <div className="text-center py-8 text-gray-500 italic">
+          <div className="text-center py-8 text-muted-foreground italic">
             Clique em "Nova Locação" para adicionar locações
           </div>
         ) : (

--- a/src/components/pdf-preview-demo.tsx
+++ b/src/components/pdf-preview-demo.tsx
@@ -113,12 +113,12 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
             {/* Header Section */}
             <div className="brick-black text-white p-4 flex justify-between items-center">
               <div className="flex items-center space-x-4">
-                <div className="w-12 h-8 bg-white flex items-center justify-center">
+                <div className="w-12 h-8 bg-card flex items-center justify-center">
                   <span className="text-[var(--brick-black)] font-bold text-xs">BRICK</span>
                 </div>
                 <div>
                   <h2 className="text-lg font-bold">MAPA DE FILMAGEM</h2>
-                  <p className="text-sm text-gray-300">Produção Audiovisual</p>
+                  <p className="text-sm text-muted-foreground">Produção Audiovisual</p>
                 </div>
               </div>
               <div className="text-right text-xs">
@@ -127,11 +127,11 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
             </div>
 
             {/* Content Preview */}
-            <div className="bg-white p-6 space-y-6 text-sm">
+            <div className="bg-background p-6 space-y-6 text-sm">
               {/* Production Info */}
               <section>
                 <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">INFORMAÇÕES DA PRODUÇÃO</h3>
-                <div className="space-y-1 text-gray-700">
+                <div className="space-y-1 text-foreground">
                   <p><strong>Título:</strong> Curta-Metragem Brick - Projeto Exemplo</p>
                   <p><strong>Data de Filmagem:</strong> 15/02/2025</p>
                   <p><strong>Roteiro:</strong> Roteiro Final v3.2 - Brick Curta</p>
@@ -142,7 +142,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
               {/* Locations */}
               <section>
                 <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">LOCAÇÕES</h3>
-                <div className="space-y-3 text-gray-700">
+                <div className="space-y-3 text-foreground">
                   <div>
                     <p className="font-semibold">Locação 1:</p>
                     <p className="ml-4">Endereço: Rua Augusta, 123 - Vila Madalena, São Paulo - SP</p>
@@ -159,7 +159,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
               {/* Scenes */}
               <section>
                 <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">CENAS PROGRAMADAS</h3>
-                <div className="space-y-3 text-gray-700">
+                <div className="space-y-3 text-foreground">
                   <div>
                     <p className="font-semibold">Cena 1A:</p>
                     <p className="ml-4">Descrição: Conversa entre protagonistas no café</p>
@@ -176,7 +176,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
               {/* Call Times */}
               <section>
                 <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">HORÁRIOS DE CHAMADA</h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-gray-700">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-foreground">
                   <div>
                     <p className="font-semibold mb-2">Equipe Técnica:</p>
                     <div className="ml-4 space-y-1">
@@ -198,7 +198,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
               {/* General Notes */}
               <section>
                 <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">OBSERVAÇÕES GERAIS</h3>
-                <div className="text-gray-700">
+                <div className="text-foreground">
                   <p>ATENÇÃO: Previsão de chuva pela manhã. Equipamento de proteção disponível no caminhão de produção. Catering será servido às 12h no local...</p>
                 </div>
               </section>
@@ -206,7 +206,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
               {/* Contacts */}
               <section>
                 <h3 className="font-bold text-base mb-3 text-[var(--brick-dark)]">CONTATOS IMPORTANTES</h3>
-                <div className="space-y-2 text-gray-700">
+                <div className="space-y-2 text-foreground">
                   <div>
                     <p>Maria Produtora - Produtora Executiva</p>
                     <p className="ml-4">Tel: (11) 99999-1234</p>
@@ -247,7 +247,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
             )}
           </div>
 
-          <div className="text-center text-gray-600 text-sm">
+          <div className="text-center text-muted-foreground text-sm">
             <p>Este é um exemplo de como fica o PDF gerado pela aplicação.</p>
             <p>O documento mantém a identidade visual da Brick com header e footer personalizados.</p>
           </div>

--- a/src/components/projects-manager.tsx
+++ b/src/components/projects-manager.tsx
@@ -138,7 +138,7 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
       case 'pausado':
         return <Badge className="bg-yellow-100 text-yellow-800">Pausado</Badge>;
       case 'concluído':
-        return <Badge className="bg-gray-100 text-gray-800">Concluído</Badge>;
+        return <Badge className="bg-muted text-foreground">Concluído</Badge>;
       default:
         return <Badge>{status}</Badge>;
     }
@@ -160,7 +160,7 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
               <div>
                 <CardTitle className="text-lg text-[var(--brick-dark)]">{project.name}</CardTitle>
                 {project.client && (
-                  <p className="text-sm text-gray-600 flex items-center mt-1">
+                  <p className="text-sm text-muted-foreground flex items-center mt-1">
                     <User className="w-3 h-3 mr-1" />
                     {project.client}
                   </p>
@@ -214,9 +214,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
         </CardHeader>
         <CardContent className="pt-0">
           {project.description && (
-            <p className="text-sm text-gray-600 mb-3 line-clamp-2">{project.description}</p>
+            <p className="text-sm text-muted-foreground mb-3 line-clamp-2">{project.description}</p>
           )}
-          <div className="flex items-center justify-between text-xs text-gray-500">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
             <div className="flex items-center space-x-4">
               <span className="flex items-center">
                 <Calendar className="w-3 h-3 mr-1" />
@@ -245,8 +245,8 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-[var(--brick-dark)]">Projetos</h2>
-          <p className="text-gray-600">Organize suas ordens do dia por projeto</p>
+          <h2 className="text-2xl font-bold text-foreground">Projetos</h2>
+          <p className="text-muted-foreground">Organize suas ordens do dia por projeto</p>
           <div className="mt-2">
             <SyncIndicator 
               lastSync={lastSync} 
@@ -273,12 +273,12 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
               Novo Projeto
             </Button>
           </DialogTrigger>
-          <DialogContent className="sm:max-w-md w-full bg-white rounded-xl p-6 shadow-lg z-50" aria-describedby="project-dialog-description">
+          <DialogContent className="sm:max-w-md w-full bg-background rounded-xl p-6 shadow-lg z-50" aria-describedby="project-dialog-description">
             <DialogHeader>
               <DialogTitle>
                 {editingProject ? 'Editar Projeto' : 'Criar Novo Projeto'}
               </DialogTitle>
-              <p id="project-dialog-description" className="text-sm text-gray-600">
+              <p id="project-dialog-description" className="text-sm text-muted-foreground">
                 {editingProject ? 'Edite as informações do projeto abaixo.' : 'Preencha os dados para criar um novo projeto para organizar suas ordens do dia.'}
               </p>
             </DialogHeader>
@@ -354,9 +354,9 @@ export function ProjectsManager({ onSelectProject }: ProjectsManagerProps) {
 
       {projects.length === 0 ? (
         <div className="text-center py-12">
-          <FolderOpen className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-gray-900 mb-2">Nenhum projeto criado</h3>
-          <p className="text-gray-600 mb-6">Comece criando seu primeiro projeto para organizar suas ordens do dia.</p>
+          <FolderOpen className="w-16 h-16 text-muted-foreground mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-foreground mb-2">Nenhum projeto criado</h3>
+          <p className="text-muted-foreground mb-6">Comece criando seu primeiro projeto para organizar suas ordens do dia.</p>
           <Button
             onClick={() => setShowNewProjectDialog(true)}
             variant="brick"

--- a/src/components/scenes-section.tsx
+++ b/src/components/scenes-section.tsx
@@ -60,18 +60,18 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
     <div
       ref={setNodeRef}
       style={style}
-      className={`border border-gray-200 rounded-lg p-4 bg-white ${isDragging ? 'shadow-lg' : ''}`}
+      className={`border border-gray-200 rounded-lg p-4 bg-card ${isDragging ? 'shadow-lg' : ''}`}
     >
       <div className="flex justify-between items-start mb-3">
         <div className="flex items-center gap-2">
           <div
             {...attributes}
             {...listeners}
-            className="cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 p-1"
+            className="cursor-grab active:cursor-grabbing text-muted-foreground hover:text-foreground p-1"
           >
             <GripVertical className="w-4 h-4" />
           </div>
-          <h3 className="font-medium text-gray-900">Cena #{index + 1}</h3>
+          <h3 className="font-medium text-foreground">Cena #{index + 1}</h3>
         </div>
         <Button
           onClick={() => onRemove(scene.id)}
@@ -83,7 +83,7 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
       </div>
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div>
-          <Label className="block text-sm font-medium text-gray-600 mb-1">
+          <Label className="block text-sm font-medium text-muted-foreground mb-1">
             Número da Cena
           </Label>
           <Input
@@ -94,7 +94,7 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
           />
         </div>
         <div className="md:col-span-2">
-          <Label className="block text-sm font-medium text-gray-600 mb-1">
+          <Label className="block text-sm font-medium text-muted-foreground mb-1">
             Descrição
           </Label>
           <Input
@@ -105,7 +105,7 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
           />
         </div>
         <div>
-          <Label className="block text-sm font-medium text-gray-600 mb-1">
+          <Label className="block text-sm font-medium text-muted-foreground mb-1">
             Tempo Estimado
           </Label>
           <Input
@@ -117,7 +117,7 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
         </div>
       </div>
       <div className="mt-4">
-        <Label className="block text-sm font-medium text-gray-600 mb-1">
+        <Label className="block text-sm font-medium text-muted-foreground mb-1">
           Elenco da Cena
         </Label>
         <Textarea
@@ -177,7 +177,7 @@ export default function ScenesSection({
         </div>
 
         {scenes.length === 0 ? (
-          <div className="text-center py-8 text-gray-500 italic">
+          <div className="text-center py-8 text-muted-foreground italic">
             Clique em "Nova Cena" para adicionar cenas ao roteiro
           </div>
         ) : (

--- a/src/components/template-manager.tsx
+++ b/src/components/template-manager.tsx
@@ -122,8 +122,8 @@ export function TemplateManager({ onSelectTemplate, currentCallSheet }: Template
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">Templates</h2>
-          <p className="text-gray-600 dark:text-gray-300">
+          <h2 className="text-2xl font-bold text-foreground">Templates</h2>
+          <p className="text-muted-foreground">
             Gerencie seus modelos de mapa de filmagem
           </p>
         </div>
@@ -135,13 +135,13 @@ export function TemplateManager({ onSelectTemplate, currentCallSheet }: Template
               Criar Template
             </Button>
           </DialogTrigger>
-          <DialogContent className="sm:max-w-md w-full bg-white rounded-xl p-6 shadow-lg z-50" aria-describedby="template-dialog-description">
+          <DialogContent className="sm:max-w-md w-full bg-background rounded-xl p-6 shadow-lg z-50" aria-describedby="template-dialog-description">
             <form onSubmit={handleCreateTemplate}>
               <DialogHeader>
                 <DialogTitle>Criar Novo Template</DialogTitle>
                 <p
                   id="template-dialog-description"
-                  className="text-sm text-gray-600"
+                  className="text-sm text-muted-foreground"
                 >
                   Salve o mapa atual como um template para reutilizar.
                 </p>
@@ -231,13 +231,13 @@ export function TemplateManager({ onSelectTemplate, currentCallSheet }: Template
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
         {isLoading ? (
           <div className="col-span-full text-center py-8">
-            <p className="text-gray-500">Carregando templates...</p>
+            <p className="text-muted-foreground">Carregando templates...</p>
           </div>
         ) : templates.length === 0 ? (
           <div className="col-span-full text-center py-8">
-            <Layers className="w-12 h-12 mx-auto text-gray-400 mb-2" />
-            <p className="text-gray-500">Nenhum template encontrado</p>
-            <p className="text-sm text-gray-400">
+            <Layers className="w-12 h-12 mx-auto text-muted-foreground mb-2" />
+            <p className="text-muted-foreground">Nenhum template encontrado</p>
+            <p className="text-sm text-muted-foreground">
               Crie seu primeiro template a partir de um mapa existente
             </p>
           </div>
@@ -268,7 +268,7 @@ export function TemplateManager({ onSelectTemplate, currentCallSheet }: Template
                   {template.description}
                 </CardDescription>
                 
-                <div className="space-y-2 text-sm text-gray-600 dark:text-gray-300 mb-4">
+                <div className="space-y-2 text-sm text-muted-foreground mb-4">
                   <div>Locações: {template.templateData.locations.length}</div>
                   <div>Cenas: {template.templateData.scenes.length}</div>
                   <div>Contatos: {template.templateData.contacts.length}</div>


### PR DESCRIPTION
## Summary
- replace hard-coded `bg-white` with theme tokens
- adjust adjacent text colors to token-based variants for dark mode

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68913375bed4832cba9faad5018b0d9e