### PR TITLE
refactor: use theme tokens instead of text-white

### DIFF
--- a/src/components/brick-header.tsx
+++ b/src/components/brick-header.tsx
@@ -22,7 +22,7 @@ export default function BrickHeader({ onExportPDF, onSave, hasUnsavedChanges }: 
                 </text>
               </svg>
             </div>
-            <div className="text-white">
+            <div className="text-[var(--brick-light)]">
               <h1 className="text-lg font-semibold">Gerador de Ordem do Dia</h1>
               <p className="text-xs text-gray-300">Produção Audiovisual</p>
             </div>

--- a/src/components/contacts-section.tsx
+++ b/src/components/contacts-section.tsx
@@ -151,14 +151,14 @@ export default function ContactsSection({
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center">
             <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
-              <Users className="text-white w-4 h-4" />
+              <Users className="text-[var(--brick-light)] w-4 h-4" />
             </div>
             <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Contatos Importantes</h2>
           </div>
           <Button
             onClick={onAdd}
             variant="brick"
-            className="text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            className="text-[var(--brick-light)] px-4 py-2 rounded-lg text-sm font-medium transition-colors"
           >
             <Plus className="w-4 h-4 mr-2" />
             Novo Contato

--- a/src/components/locations-section.tsx
+++ b/src/components/locations-section.tsx
@@ -139,14 +139,14 @@ export default function LocationsSection({
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center">
             <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
-              <MapPin className="text-white w-4 h-4" />
+              <MapPin className="text-[var(--brick-light)] w-4 h-4" />
             </div>
             <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Locações</h2>
           </div>
           <Button
             onClick={onAdd}
             variant="brick"
-            className="text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            className="text-[var(--brick-light)] px-4 py-2 rounded-lg text-sm font-medium transition-colors"
           >
             <Plus className="w-4 h-4 mr-2" />
             Nova Locação

--- a/src/components/pdf-preview-demo.tsx
+++ b/src/components/pdf-preview-demo.tsx
@@ -100,7 +100,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
 
   return (
     <Card className="max-w-4xl mx-auto my-8">
-      <CardHeader className="bg-[var(--brick-dark)] text-white">
+      <CardHeader className="bg-[var(--brick-dark)] text-[var(--brick-light)]">
         <CardTitle className="flex items-center">
           <FileText className="w-6 h-6 mr-3" />
           Demonstração do PDF Gerado
@@ -111,7 +111,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
           {/* PDF Preview Visual Representation */}
           <div className="border-2 border-gray-300 rounded-lg overflow-hidden shadow-lg">
             {/* Header Section */}
-            <div className="brick-black text-white p-4 flex justify-between items-center">
+            <div className="brick-black text-[var(--brick-light)] p-4 flex justify-between items-center">
               <div className="flex items-center space-x-4">
                 <div className="w-12 h-8 bg-card flex items-center justify-center">
                   <span className="text-[var(--brick-black)] font-bold text-xs">BRICK</span>
@@ -220,7 +220,7 @@ export default function PDFPreviewDemo({ onClose }: PDFPreviewDemoProps) {
             </div>
 
             {/* Footer */}
-            <div className="brick-black text-white p-3 text-xs flex justify-between">
+            <div className="brick-black text-[var(--brick-light)] p-3 text-xs flex justify-between">
               <span>BRICK Produtora - 7 anos de experiência em produção audiovisual</span>
               <span>Página 1 de 1</span>
             </div>

--- a/src/components/production-info.tsx
+++ b/src/components/production-info.tsx
@@ -25,7 +25,7 @@ export default function ProductionInfo({
       <CardContent className="p-6">
         <div className="flex items-center mb-6">
           <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
-            <Film className="text-white w-4 h-4" />
+            <Film className="text-[var(--brick-light)] w-4 h-4" />
           </div>
           <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Informações da Produção</h2>
         </div>

--- a/src/components/scenes-section.tsx
+++ b/src/components/scenes-section.tsx
@@ -162,14 +162,14 @@ export default function ScenesSection({
         <div className="flex items-center justify-between mb-6">
           <div className="flex items-center">
             <div className="w-8 h-8 bg-[var(--brick-dark)] rounded-lg flex items-center justify-center mr-3">
-              <Video className="text-white w-4 h-4" />
+              <Video className="text-[var(--brick-light)] w-4 h-4" />
             </div>
             <h2 className="text-xl font-semibold text-[var(--brick-dark)]">Cenas Programadas</h2>
           </div>
           <Button
             onClick={onAdd}
             variant="brick"
-            className="text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+            className="text-[var(--brick-light)] px-4 py-2 rounded-lg text-sm font-medium transition-colors"
           >
             <Plus className="w-4 h-4 mr-2" />
             Nova Cena


### PR DESCRIPTION
## Summary
- replace hard-coded `text-white` with palette tokens for header and preview components
- update icons and buttons to use `var(--brick-light)` for better contrast

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689164697f38832c9504bf4a8d4ea42c