### PR TITLE
feat: standardize z-index layers

### DIFF
--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -12,7 +12,7 @@ const NavigationMenu = React.forwardRef<
   <NavigationMenuPrimitive.Root
     ref={ref}
     className={cn(
-      "relative z-10 flex max-w-max flex-1 items-center justify-center",
+      "relative z-navigation flex max-w-max flex-1 items-center justify-center",
       className
     )}
     {...props}
@@ -104,7 +104,7 @@ const NavigationMenuIndicator = React.forwardRef<
   <NavigationMenuPrimitive.Indicator
     ref={ref}
     className={cn(
-      "top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
+      "top-full z-navigation flex h-1.5 items-end justify-center overflow-hidden data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in",
       className
     )}
     {...props}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -14,7 +14,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "fixed top-0 z-toast flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,8 @@
   --brick-light: hsl(0, 0%, 98%);
   --brick-red: hsl(0, 79%, 43%);
   --brick-red-hover: hsl(0, 84%, 38%);
+  --z-navigation: 10;
+  --z-toast: 40;
   --z-dialog-overlay: 50;
   --z-dialog-content: 60;
 }
@@ -93,5 +95,13 @@
 
   [data-radix-dialog-content] {
     z-index: var(--z-dialog-content);
+  }
+
+  .z-navigation {
+    z-index: var(--z-navigation);
+  }
+
+  .z-toast {
+    z-index: var(--z-toast);
   }
 }


### PR DESCRIPTION
## Summary
- add reusable z-index tokens for navigation and toast
- apply new utilities to toast viewport and navigation menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891686d0348832c9dd507e124f0bcb4