### PR TITLE
feat: add edit and delete icons in team members page

### DIFF
--- a/src/pages/team-members.tsx
+++ b/src/pages/team-members.tsx
@@ -7,7 +7,7 @@ import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@
 import { BrickHeader, BrickFooter } from "@/components";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/api";
-import { Plus, Check } from "lucide-react";
+import { Plus, Check, Edit, Trash2 } from "lucide-react";
 import { Link } from "wouter";
 
 interface TeamMember {
@@ -233,6 +233,7 @@ export default function TeamMembers() {
                     <TableCell>
                       <div className="flex gap-2">
                         <Button size="sm" variant="secondary" onClick={() => handleEdit(member)}>
+                          <Edit className='w-4 h-4 mr-1' />
                           Editar
                         </Button>
                         <Button
@@ -240,6 +241,7 @@ export default function TeamMembers() {
                           variant="destructive"
                           onClick={() => deleteMutation.mutate(member.id)}
                         >
+                          <Trash2 className='w-4 h-4 mr-1' />
                           Excluir
                         </Button>
                       </div>


### PR DESCRIPTION
## Summary
- import and display Edit/Trash2 icons for team member actions

## Testing
- `npm test` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68923e07d3c4832cb215edc36ef43913