### PR TITLE
Handle empty API responses

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,13 +3,21 @@ const API_BASE =
     ? process.env.API_BASE_URL || ''
     : import.meta.env.VITE_API_BASE_URL || '';
 
-export async function apiRequest(path: string, options?: RequestInit) {
+export async function apiRequest<T = unknown>(
+  path: string,
+  options?: RequestInit,
+): Promise<T | undefined> {
   const url = API_BASE ? new URL(path, API_BASE).toString() : path;
   const response = await fetch(url, options);
   if (!response.ok) {
     throw new Error(`HTTP error! status: ${response.status}`);
   }
-  return response.json();
+
+  if (response.status === 204 || response.headers.get("content-length") === "0") {
+    return undefined;
+  }
+
+  return response.json() as Promise<T>;
 }
 
 export { API_BASE };

--- a/src/pages/team-members.tsx
+++ b/src/pages/team-members.tsx
@@ -92,8 +92,9 @@ export default function TeamMembers() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: string) =>
-      apiRequest(`/api/team-members/${id}`, { method: "DELETE" }),
+    mutationFn: async (id: string) => {
+      await apiRequest(`/api/team-members/${id}`, { method: "DELETE" });
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["/api/team-members"] });
       toast({ title: "Membro removido" });


### PR DESCRIPTION
## Summary
- avoid parsing JSON for empty API responses
- handle DELETE team member requests without expecting a response body

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689241a203d8832c94f66c550ebd735d