### PR TITLE
fix: ensure delete methods return true

### DIFF
--- a/server/delete.test.ts
+++ b/server/delete.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { DatabaseStorage } from './storage';
+
+async function run() {
+  const storage = new DatabaseStorage();
+
+  const callSheet = await storage.createCallSheet({
+    productionTitle: 'Test',
+    shootingDate: '2024-01-01',
+    locations: [],
+    scenes: [],
+    contacts: [],
+    crewCallTimes: [],
+    castCallTimes: [],
+    generalNotes: ''
+  });
+  assert.equal(await storage.deleteCallSheet(callSheet.id), true);
+
+  const template = await storage.createTemplate({
+    name: 'T',
+    description: 'D',
+    category: 'C',
+    templateData: {
+      locations: [],
+      scenes: [],
+      contacts: [],
+      crewCallTimes: [],
+      castCallTimes: [],
+      generalNotes: ''
+    }
+  });
+  assert.equal(await storage.deleteTemplate(template.id), true);
+
+  const project = await storage.createProject({ name: 'P' });
+  assert.equal(await storage.deleteProject(project.id), true);
+
+  const member = await storage.createTeamMember({ name: 'M' });
+  assert.equal(await storage.deleteTeamMember(member.id), true);
+
+  console.log('Deletion tests passed');
+}
+
+run();

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -308,8 +308,9 @@ export class DatabaseStorage implements IStorage {
     try {
       const result = await db
         .delete(callSheets)
-        .where(eq(callSheets.id, id));
-      
+        .where(eq(callSheets.id, id))
+        .returning({ id: callSheets.id });
+
       this.isDbConnected = true;
       return result.length > 0;
     } catch (error) {
@@ -389,8 +390,9 @@ export class DatabaseStorage implements IStorage {
     try {
       const result = await db
         .delete(templates)
-        .where(eq(templates.id, id));
-      
+        .where(eq(templates.id, id))
+        .returning({ id: templates.id });
+
       this.isDbConnected = true;
       return result.length > 0;
     } catch (error) {
@@ -482,7 +484,10 @@ export class DatabaseStorage implements IStorage {
 
   async deleteProject(id: string): Promise<boolean> {
     try {
-      const result = await db.delete(projects).where(eq(projects.id, id));
+      const result = await db
+        .delete(projects)
+        .where(eq(projects.id, id))
+        .returning({ id: projects.id });
       this.isDbConnected = true;
       return result.length > 0;
     } catch (error) {
@@ -547,7 +552,10 @@ export class DatabaseStorage implements IStorage {
 
   async deleteTeamMember(id: string): Promise<boolean> {
     try {
-      const result = await db.delete(teamMembers).where(eq(teamMembers.id, id));
+      const result = await db
+        .delete(teamMembers)
+        .where(eq(teamMembers.id, id))
+        .returning({ id: teamMembers.id });
       this.isDbConnected = true;
       return result.length > 0;
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure server deletions check affected rows
- add manual tests for deletion

## Testing
- `node_modules/.bin/tsc --noEmit` *(fails: Could not find a declaration file for module 'express', etc.)*
- `npx tsx server/delete.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6892467979f0832c9c61723dba791616