### PR TITLE
Allow optional IDs in insert schemas

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -182,17 +182,17 @@ export const teamMembers = pgTable('team_members', {
 export const insertProjectSchema = createInsertSchema(projects).omit({
   createdAt: true,
   updatedAt: true,
-});
+}).extend({ id: z.string().optional() });
 
 export const insertCallSheetSchema = createInsertSchema(callSheets).omit({
   createdAt: true,
   updatedAt: true,
-});
+}).extend({ id: z.string().optional() });
 
 export const insertTemplateSchema = createInsertSchema(templates).omit({
   createdAt: true,
   updatedAt: true,
-});
+}).extend({ id: z.string().optional() });
 
 export const insertTeamMemberSchema = teamMemberSchema.omit({
   id: true,

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -218,11 +218,10 @@ export function useProjects() {
     error: query.error,
     lastSync,
     addProject: (name: string, description?: string, client?: string) => {
-      return createMutation.mutate({ 
-        id: nanoid(),
-        name, 
-        description: description || '', 
-        client: client || '' 
+      return createMutation.mutate({
+        name,
+        description: description || '',
+        client: client || ''
       });
     },
     updateProject: (id: string, updates: Partial<InsertProject>) => {

--- a/src/hooks/use-sync-storage.ts
+++ b/src/hooks/use-sync-storage.ts
@@ -226,11 +226,10 @@ export function useSyncProjects() {
     error: query.error,
     lastSync,
     addProject: (name: string, description?: string, client?: string) => {
-      return createMutation.mutate({ 
-        id: nanoid(),
-        name, 
-        description: description || '', 
-        client: client || '' 
+      return createMutation.mutate({
+        name,
+        description: description || '',
+        client: client || ''
       });
     },
     updateProject: (id: string, updates: Partial<InsertProject>) => {


### PR DESCRIPTION
## Summary
- allow call sheet, project and template insert schemas to accept optional ids
- remove explicit id requirement when creating projects on the client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npx tsx -e "import('./server/storage.ts').then(async (m) => { const storage = new m.DatabaseStorage(); const project = await storage.createProject({ name: 'ProjSemId' }); console.log(project); process.exit(0); });"`


------
https://chatgpt.com/codex/tasks/task_e_68924d65b690832c8223336b52fb9c99