### PR TITLE
refactor: centralize server error handling

### DIFF
--- a/server/async-handler.ts
+++ b/server/async-handler.ts
@@ -1,0 +1,9 @@
+import type { Request, Response, NextFunction, RequestHandler } from "express";
+
+export const asyncHandler = (
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<any>
+): RequestHandler => {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+};

--- a/server/error-handler.ts
+++ b/server/error-handler.ts
@@ -1,0 +1,19 @@
+import type { Request, Response, NextFunction } from "express";
+import { ZodError } from "zod";
+
+export function errorHandler(
+  err: any,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+): void {
+  if (err instanceof ZodError) {
+    res.status(400).json({ error: "Validation error", details: err.issues });
+    return;
+  }
+
+  const status = err.status || err.statusCode || 500;
+  const message = err.message || "Internal Server Error";
+  res.status(status).json({ error: message });
+  console.error(err);
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
-import express, { type Request, Response, NextFunction } from "express";
+import express from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+import { errorHandler } from "./error-handler";
 
 const app = express();
 app.use(express.json());
@@ -39,13 +40,7 @@ app.use((req, res, next) => {
 (async () => {
   const server = await registerRoutes(app);
 
-  app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
-    const status = err.status || err.statusCode || 500;
-    const message = err.message || "Internal Server Error";
-
-    res.status(status).json({ message });
-    throw err;
-  });
+  app.use(errorHandler);
 
   // importantly only setup vite in development and after
   // setting up all the other routes so the catch-all route

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,7 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { insertCallSheetSchema, insertTemplateSchema, insertProjectSchema, insertTeamMemberSchema } from "@shared/schema";
 import { testConnection } from "./db";
-import { ZodError } from "zod";
+import { asyncHandler } from "./async-handler";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Test database connection on startup
@@ -12,101 +12,58 @@ export async function registerRoutes(app: Express): Promise<Server> {
     console.warn('❌ Unable to connect to the database. Falling back to in-memory storage.');
   }
   // Call Sheet routes
-  app.get("/api/call-sheets", async (req, res) => {
-    try {
+    app.get("/api/call-sheets", asyncHandler(async (_req, res) => {
       const callSheets = await storage.listCallSheets();
       res.json(callSheets);
-    } catch (error) {
-      console.error("Route error fetching call sheets:", error);
-      res.status(500).json({ error: "Failed to fetch call sheets" });
-    }
-  });
+    }));
 
-  app.get("/api/call-sheets/:id", async (req, res) => {
-    try {
+    app.get("/api/call-sheets/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const callSheet = await storage.getCallSheet(id);
-      
+
       if (!callSheet) {
         return res.status(404).json({ error: "Call sheet not found" });
       }
-      
-      res.json(callSheet);
-    } catch (error) {
-      console.error("Error fetching call sheet:", error);
-      res.status(500).json({ error: "Failed to fetch call sheet" });
-    }
-  });
 
-  app.post("/api/call-sheets", async (req, res) => {
-    try {
+      res.json(callSheet);
+    }));
+
+    app.post("/api/call-sheets", asyncHandler(async (req, res) => {
       const validatedData = insertCallSheetSchema.parse(req.body);
       const callSheet = await storage.createCallSheet(validatedData);
       res.status(201).json(callSheet);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return res.status(400).json({ 
-          error: "Validation error", 
-          details: error.issues 
-        });
-      }
-      console.error("Error creating call sheet:", error);
-      res.status(500).json({ error: "Failed to create call sheet" });
-    }
-  });
+    }));
 
-  app.put("/api/call-sheets/:id", async (req, res) => {
-    try {
+    app.put("/api/call-sheets/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const validatedData = insertCallSheetSchema.partial().parse(req.body);
       const callSheet = await storage.updateCallSheet(id, validatedData);
-      
+
       if (!callSheet) {
         return res.status(404).json({ error: "Call sheet not found" });
       }
-      
-      res.json(callSheet);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return res.status(400).json({ 
-          error: "Validation error", 
-          details: error.issues 
-        });
-      }
-      console.error("Error updating call sheet:", error);
-      res.status(500).json({ error: "Failed to update call sheet" });
-    }
-  });
 
-  app.delete("/api/call-sheets/:id", async (req, res) => {
-    try {
+      res.json(callSheet);
+    }));
+
+    app.delete("/api/call-sheets/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const success = await storage.deleteCallSheet(id);
-      
+
       if (!success) {
         return res.status(404).json({ error: "Call sheet not found" });
       }
-      
+
       res.status(204).send();
-    } catch (error) {
-      console.error("Error deleting call sheet:", error);
-      res.status(500).json({ error: "Failed to delete call sheet" });
-    }
-  });
+    }));
 
   // Project routes
-  app.get("/api/projects", async (_req, res) => {
-    try {
+    app.get("/api/projects", asyncHandler(async (_req, res) => {
       const projects = await storage.listProjects();
       res.json(projects);
-    } catch (error) {
-      console.error("Route error fetching projects:", error);
-      res.status(500).json({ error: "Failed to fetch projects" });
-    }
-  });
+    }));
 
-  app.get("/api/projects/:id", async (req, res) => {
-    try {
+    app.get("/api/projects/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const project = await storage.getProject(id);
 
@@ -115,31 +72,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       res.json(project);
-    } catch (error) {
-      console.error("Error fetching project:", error);
-      res.status(500).json({ error: "Failed to fetch project" });
-    }
-  });
+    }));
 
-  app.post("/api/projects", async (req, res) => {
-    try {
+    app.post("/api/projects", asyncHandler(async (req, res) => {
       const validatedData = insertProjectSchema.parse(req.body);
       const project = await storage.createProject(validatedData);
       res.status(201).json(project);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return res.status(400).json({
-          error: "Validation error",
-          details: error.issues
-        });
-      }
-      console.error("Error creating project:", error);
-      res.status(500).json({ error: "Failed to create project" });
-    }
-  });
+    }));
 
-  app.put("/api/projects/:id", async (req, res) => {
-    try {
+    app.put("/api/projects/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const validatedData = insertProjectSchema.partial().parse(req.body);
       const project = await storage.updateProject(id, validatedData);
@@ -149,20 +90,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       res.json(project);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return res.status(400).json({
-          error: "Validation error",
-          details: error.issues
-        });
-      }
-      console.error("Error updating project:", error);
-      res.status(500).json({ error: "Failed to update project" });
-    }
-  });
+    }));
 
-  app.delete("/api/projects/:id", async (req, res) => {
-    try {
+    app.delete("/api/projects/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const success = await storage.deleteProject(id);
 
@@ -171,42 +101,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       res.status(204).send();
-    } catch (error) {
-      console.error("Error deleting project:", error);
-      res.status(500).json({ error: "Failed to delete project" });
-    }
-  });
+    }));
 
   // Team member routes
-  app.get("/api/team-members", async (_req, res) => {
-    try {
+    app.get("/api/team-members", asyncHandler(async (_req, res) => {
       const members = await storage.listTeamMembers();
       res.json(members);
-    } catch (error) {
-      console.error("Error fetching team members:", error);
-      res.status(500).json({ error: "Failed to fetch team members" });
-    }
-  });
+    }));
 
-  app.post("/api/team-members", async (req, res) => {
-    try {
+    app.post("/api/team-members", asyncHandler(async (req, res) => {
       const validatedData = insertTeamMemberSchema.parse(req.body);
       const member = await storage.createTeamMember(validatedData);
       res.status(201).json(member);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return res.status(400).json({
-          error: "Validation error",
-          details: error.issues
-        });
-      }
-      console.error("Error creating team member:", error);
-      res.status(500).json({ error: "Failed to create team member" });
-    }
-  });
+    }));
 
-  app.put("/api/team-members/:id", async (req, res) => {
-    try {
+    app.put("/api/team-members/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const validatedData = insertTeamMemberSchema.partial().parse(req.body);
       const member = await storage.updateTeamMember(id, validatedData);
@@ -216,20 +125,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       res.json(member);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return res.status(400).json({
-          error: "Validation error",
-          details: error.issues
-        });
-      }
-      console.error("Error updating team member:", error);
-      res.status(500).json({ error: "Failed to update team member" });
-    }
-  });
+    }));
 
-  app.delete("/api/team-members/:id", async (req, res) => {
-    try {
+    app.delete("/api/team-members/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const success = await storage.deleteTeamMember(id);
 
@@ -238,112 +136,66 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       res.status(204).send();
-    } catch (error) {
-      console.error("Error deleting team member:", error);
-      res.status(500).json({ error: "Failed to delete team member" });
-    }
-  });
+    }));
 
   // Template routes
-  app.get("/api/templates", async (req, res) => {
-    try {
+    app.get("/api/templates", asyncHandler(async (req, res) => {
       const { category } = req.query;
       let templates;
-      
+
       if (category) {
         templates = await storage.getTemplatesByCategory(category as string);
       } else {
         templates = await storage.listTemplates();
       }
-      
-      res.json(templates);
-    } catch (error) {
-      console.error("Error fetching templates:", error);
-      res.status(500).json({ error: "Failed to fetch templates" });
-    }
-  });
 
-  app.get("/api/templates/defaults", async (req, res) => {
-    try {
+      res.json(templates);
+    }));
+
+    app.get("/api/templates/defaults", asyncHandler(async (_req, res) => {
       const templates = await storage.getDefaultTemplates();
       res.json(templates);
-    } catch (error) {
-      console.error("Error fetching default templates:", error);
-      res.status(500).json({ error: "Failed to fetch default templates" });
-    }
-  });
+    }));
 
-  app.get("/api/templates/:id", async (req, res) => {
-    try {
+    app.get("/api/templates/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const template = await storage.getTemplate(id);
-      
+
       if (!template) {
         return res.status(404).json({ error: "Template not found" });
       }
-      
-      res.json(template);
-    } catch (error) {
-      console.error("Error fetching template:", error);
-      res.status(500).json({ error: "Failed to fetch template" });
-    }
-  });
 
-  app.post("/api/templates", async (req, res) => {
-    try {
+      res.json(template);
+    }));
+
+    app.post("/api/templates", asyncHandler(async (req, res) => {
       const validatedData = insertTemplateSchema.parse(req.body);
       const template = await storage.createTemplate(validatedData);
       res.status(201).json(template);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return res.status(400).json({ 
-          error: "Validation error", 
-          details: error.issues 
-        });
-      }
-      console.error("Error creating template:", error);
-      res.status(500).json({ error: "Failed to create template" });
-    }
-  });
+    }));
 
-  app.put("/api/templates/:id", async (req, res) => {
-    try {
+    app.put("/api/templates/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const validatedData = insertTemplateSchema.partial().parse(req.body);
       const template = await storage.updateTemplate(id, validatedData);
-      
+
       if (!template) {
         return res.status(404).json({ error: "Template not found" });
       }
-      
-      res.json(template);
-    } catch (error) {
-      if (error instanceof ZodError) {
-        return res.status(400).json({ 
-          error: "Validation error", 
-          details: error.issues 
-        });
-      }
-      console.error("Error updating template:", error);
-      res.status(500).json({ error: "Failed to update template" });
-    }
-  });
 
-  app.delete("/api/templates/:id", async (req, res) => {
-    try {
+      res.json(template);
+    }));
+
+    app.delete("/api/templates/:id", asyncHandler(async (req, res) => {
       const { id } = req.params;
       const success = await storage.deleteTemplate(id);
-      
+
       if (!success) {
         return res.status(404).json({ error: "Template not found" });
       }
-      
+
       res.status(204).send();
-    } catch (error) {
-      console.error("Error deleting template:", error);
-      res.status(500).json({ error: "Failed to delete template" });
-    }
-  });
+    }));
 
   const httpServer = createServer(app);
   return httpServer;


### PR DESCRIPTION
## Summary
- add asyncHandler utility and centralized error middleware
- refactor API routes to use asyncHandler for cleaner control flow
- standardize JSON error responses and register middleware

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689277faf434832c8495f50592ae7a1a