### PR TITLE
refactor: centralize logging

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -1,6 +1,7 @@
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from "@shared/schema";
+import { logger } from "@shared/logger";
 
 let db: ReturnType<typeof drizzle> | null = null;
 let client: postgres.Sql | null = null;
@@ -21,7 +22,7 @@ if (process.env.DATABASE_URL) {
 
   db = drizzle(client, { schema });
 } else {
-  console.warn('DATABASE_URL not set – falling back to in-memory storage');
+    logger.warn('DATABASE_URL not set – falling back to in-memory storage');
 }
 
 export { db };
@@ -31,10 +32,10 @@ export async function testConnection() {
   if (!client) return false;
   try {
     await client`SELECT 1`;
-    console.log('✅ Database connection successful');
+      logger.log('✅ Database connection successful');
     return true;
   } catch (error: any) {
-    console.error('❌ Database connection failed:', error.message);
+      logger.error('❌ Database connection failed:', error.message);
     return false;
   }
 }

--- a/server/delete.test.ts
+++ b/server/delete.test.ts
@@ -37,7 +37,6 @@ async function run() {
   const member = await storage.createTeamMember({ name: 'M' });
   assert.equal(await storage.deleteTeamMember(member.id), true);
 
-  console.log('Deletion tests passed');
 }
 
 run();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,12 +4,13 @@ import { storage } from "./storage";
 import { insertCallSheetSchema, insertTemplateSchema, insertProjectSchema, insertTeamMemberSchema } from "@shared/schema";
 import { testConnection } from "./db";
 import { ZodError } from "zod";
+import { logger } from "@shared/logger";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Test database connection on startup
   const connected = await testConnection();
   if (!connected) {
-    console.warn('❌ Unable to connect to the database. Falling back to in-memory storage.');
+    logger.warn('❌ Unable to connect to the database. Falling back to in-memory storage.');
   }
   // Call Sheet routes
   app.get("/api/call-sheets", async (req, res) => {
@@ -17,7 +18,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const callSheets = await storage.listCallSheets();
       res.json(callSheets);
     } catch (error) {
-      console.error("Route error fetching call sheets:", error);
+      logger.error("Route error fetching call sheets:", error);
       res.status(500).json({ error: "Failed to fetch call sheets" });
     }
   });
@@ -33,7 +34,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(callSheet);
     } catch (error) {
-      console.error("Error fetching call sheet:", error);
+      logger.error("Error fetching call sheet:", error);
       res.status(500).json({ error: "Failed to fetch call sheet" });
     }
   });
@@ -50,7 +51,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           details: error.issues 
         });
       }
-      console.error("Error creating call sheet:", error);
+      logger.error("Error creating call sheet:", error);
       res.status(500).json({ error: "Failed to create call sheet" });
     }
   });
@@ -73,7 +74,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           details: error.issues 
         });
       }
-      console.error("Error updating call sheet:", error);
+      logger.error("Error updating call sheet:", error);
       res.status(500).json({ error: "Failed to update call sheet" });
     }
   });
@@ -89,7 +90,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.status(204).send();
     } catch (error) {
-      console.error("Error deleting call sheet:", error);
+      logger.error("Error deleting call sheet:", error);
       res.status(500).json({ error: "Failed to delete call sheet" });
     }
   });
@@ -100,7 +101,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const projects = await storage.listProjects();
       res.json(projects);
     } catch (error) {
-      console.error("Route error fetching projects:", error);
+      logger.error("Route error fetching projects:", error);
       res.status(500).json({ error: "Failed to fetch projects" });
     }
   });
@@ -116,7 +117,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       res.json(project);
     } catch (error) {
-      console.error("Error fetching project:", error);
+      logger.error("Error fetching project:", error);
       res.status(500).json({ error: "Failed to fetch project" });
     }
   });
@@ -133,7 +134,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           details: error.issues
         });
       }
-      console.error("Error creating project:", error);
+      logger.error("Error creating project:", error);
       res.status(500).json({ error: "Failed to create project" });
     }
   });
@@ -156,7 +157,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           details: error.issues
         });
       }
-      console.error("Error updating project:", error);
+      logger.error("Error updating project:", error);
       res.status(500).json({ error: "Failed to update project" });
     }
   });
@@ -172,7 +173,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       res.status(204).send();
     } catch (error) {
-      console.error("Error deleting project:", error);
+      logger.error("Error deleting project:", error);
       res.status(500).json({ error: "Failed to delete project" });
     }
   });
@@ -183,7 +184,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const members = await storage.listTeamMembers();
       res.json(members);
     } catch (error) {
-      console.error("Error fetching team members:", error);
+      logger.error("Error fetching team members:", error);
       res.status(500).json({ error: "Failed to fetch team members" });
     }
   });
@@ -200,7 +201,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           details: error.issues
         });
       }
-      console.error("Error creating team member:", error);
+      logger.error("Error creating team member:", error);
       res.status(500).json({ error: "Failed to create team member" });
     }
   });
@@ -223,7 +224,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           details: error.issues
         });
       }
-      console.error("Error updating team member:", error);
+      logger.error("Error updating team member:", error);
       res.status(500).json({ error: "Failed to update team member" });
     }
   });
@@ -239,7 +240,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       res.status(204).send();
     } catch (error) {
-      console.error("Error deleting team member:", error);
+      logger.error("Error deleting team member:", error);
       res.status(500).json({ error: "Failed to delete team member" });
     }
   });
@@ -258,7 +259,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(templates);
     } catch (error) {
-      console.error("Error fetching templates:", error);
+      logger.error("Error fetching templates:", error);
       res.status(500).json({ error: "Failed to fetch templates" });
     }
   });
@@ -268,7 +269,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const templates = await storage.getDefaultTemplates();
       res.json(templates);
     } catch (error) {
-      console.error("Error fetching default templates:", error);
+      logger.error("Error fetching default templates:", error);
       res.status(500).json({ error: "Failed to fetch default templates" });
     }
   });
@@ -284,7 +285,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.json(template);
     } catch (error) {
-      console.error("Error fetching template:", error);
+      logger.error("Error fetching template:", error);
       res.status(500).json({ error: "Failed to fetch template" });
     }
   });
@@ -301,7 +302,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           details: error.issues 
         });
       }
-      console.error("Error creating template:", error);
+      logger.error("Error creating template:", error);
       res.status(500).json({ error: "Failed to create template" });
     }
   });
@@ -324,7 +325,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           details: error.issues 
         });
       }
-      console.error("Error updating template:", error);
+      logger.error("Error updating template:", error);
       res.status(500).json({ error: "Failed to update template" });
     }
   });
@@ -340,7 +341,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       res.status(204).send();
     } catch (error) {
-      console.error("Error deleting template:", error);
+      logger.error("Error deleting template:", error);
       res.status(500).json({ error: "Failed to delete template" });
     }
   });

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -15,6 +15,7 @@ import {
 } from "@shared/schema";
 import { db } from "./db";
 import { eq } from "drizzle-orm";
+import { logger } from "@shared/logger";
 
 export interface IStorage {
   // Call sheet operations
@@ -249,7 +250,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return callSheet || undefined;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.getCallSheet(id);
     }
   }
@@ -277,7 +278,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return created;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.createCallSheet(callSheet);
     }
   }
@@ -299,7 +300,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return updated || undefined;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.updateCallSheet(id, updates);
     }
   }
@@ -314,7 +315,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result.length > 0;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.deleteCallSheet(id);
     }
   }
@@ -325,7 +326,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.listCallSheets();
     }
   }
@@ -337,7 +338,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return template || undefined;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.getTemplate(id);
     }
   }
@@ -359,7 +360,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return created;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.createTemplate(template);
     }
   }
@@ -381,7 +382,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return updated || undefined;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.updateTemplate(id, updates);
     }
   }
@@ -396,7 +397,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result.length > 0;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.deleteTemplate(id);
     }
   }
@@ -407,7 +408,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.listTemplates();
     }
   }
@@ -418,7 +419,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.getTemplatesByCategory(category);
     }
   }
@@ -429,7 +430,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.getDefaultTemplates();
     }
   }
@@ -441,7 +442,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return project || undefined;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.getProject(id);
     }
   }
@@ -463,7 +464,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return created;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.createProject(project);
     }
   }
@@ -477,7 +478,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return updated || undefined;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.updateProject(id, updates);
     }
   }
@@ -491,7 +492,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result.length > 0;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.deleteProject(id);
     }
   }
@@ -502,7 +503,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.listProjects();
     }
   }
@@ -514,7 +515,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return teamMember || undefined;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.getTeamMember(id);
     }
   }
@@ -532,7 +533,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return created;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.createTeamMember(teamMember);
     }
   }
@@ -545,7 +546,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return updated || undefined;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.updateTeamMember(id, updates);
     }
   }
@@ -559,7 +560,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result.length > 0;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.deleteTeamMember(id);
     }
   }
@@ -570,7 +571,7 @@ export class DatabaseStorage implements IStorage {
       this.isDbConnected = true;
       return result;
     } catch (error) {
-      console.warn('Database error, using memory storage:', error.message);
+      logger.warn('Database error, using memory storage:', error.message);
       return this.fallbackStorage.listTeamMembers();
     }
   }

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -5,6 +5,7 @@ import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
+import { logger } from "@shared/logger";
 
 const viteLogger = createLogger();
 
@@ -16,7 +17,7 @@ export function log(message: string, source = "express") {
     hour12: true,
   });
 
-  console.log(`${formattedTime} [${source}] ${message}`);
+    logger.log(`${formattedTime} [${source}] ${message}`);
 }
 
 export async function setupVite(app: Express, server: Server) {

--- a/shared/logger.ts
+++ b/shared/logger.ts
@@ -1,0 +1,17 @@
+export type LogMethod = (...args: unknown[]) => void;
+
+const createLogger = (method: LogMethod): LogMethod => {
+  return (...args: unknown[]) => {
+    if (process.env.NODE_ENV !== 'production') {
+      method(...args);
+    }
+  };
+};
+
+export const logger = {
+  log: createLogger(console.log),
+  warn: createLogger(console.warn),
+  error: createLogger(console.error),
+};
+
+export default logger;

--- a/src/hooks/use-call-sheet-history.tsx
+++ b/src/hooks/use-call-sheet-history.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/api";
 import type { CallSheet } from "@shared/schema";
+import { logger } from "@shared/logger";
 
 export function useCallSheetHistory() {
   return useQuery({
@@ -13,7 +14,7 @@ export function useCallSheetHistory() {
           new Date(a.updatedAt || a.createdAt || '').getTime()
         );
       } catch (error) {
-        console.warn('Erro de conexão com banco, usando histórico local:', error);
+          logger.warn('Erro de conexão com banco, usando histórico local:', error);
         return getLocalHistory();
       }
     },
@@ -30,7 +31,7 @@ function getLocalHistory(): CallSheet[] {
       new Date(a.updatedAt || a.createdAt || '').getTime()
     );
   } catch (error) {
-    console.error('Erro ao carregar histórico local:', error);
+      logger.error('Erro ao carregar histórico local:', error);
     return [];
   }
 }
@@ -47,7 +48,7 @@ export function useCreateCallSheet() {
           body: JSON.stringify(callSheet),
         }) as CallSheet;
       } catch (error) {
-        console.warn('Salvando ordem do dia localmente devido a erro de conexão:', error);
+          logger.warn('Salvando ordem do dia localmente devido a erro de conexão:', error);
         return saveCallSheetLocally(callSheet);
       }
     },
@@ -74,7 +75,7 @@ function saveCallSheetLocally(callSheet: CallSheet): CallSheet {
     
     return newCallSheet;
   } catch (error) {
-    console.error('Erro ao salvar ordem do dia localmente:', error);
+      logger.error('Erro ao salvar ordem do dia localmente:', error);
     throw new Error('Falha ao salvar ordem do dia');
   }
 }

--- a/src/hooks/use-call-sheet.tsx
+++ b/src/hooks/use-call-sheet.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { CallSheet, Location, Scene, Contact, CallTime, Attachment } from "@shared/schema";
 import { nanoid } from "nanoid";
+import { logger } from "@shared/logger";
 
 const STORAGE_KEY = "brick-call-sheet";
 
@@ -250,10 +251,10 @@ export function useCallSheet() {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(dataToSave));
       setHasUnsavedChanges(false);
       return true;
-    } catch (error) {
-      console.error("Error saving to storage:", error);
-      return false;
-    }
+      } catch (error) {
+        logger.error("Error saving to storage:", error);
+        return false;
+      }
   };
 
   const loadFromStorage = () => {
@@ -265,9 +266,9 @@ export function useCallSheet() {
         setHasUnsavedChanges(false);
         return true;
       }
-    } catch (error) {
-      console.error("Error loading from storage:", error);
-    }
+      } catch (error) {
+        logger.error("Error loading from storage:", error);
+      }
     return false;
   };
 

--- a/src/hooks/use-project-call-sheets.tsx
+++ b/src/hooks/use-project-call-sheets.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { CallSheet } from "@shared/schema";
 import { nanoid } from "nanoid";
+import { logger } from "@shared/logger";
 
 const STORAGE_KEY = "brick-project-call-sheets";
 
@@ -28,7 +29,7 @@ export function useProjectCallSheets(projectId?: string) {
         return true;
       }
     } catch (error) {
-      console.error("Error loading project call sheets from storage:", error);
+      logger.error("Error loading project call sheets from storage:", error);
     }
     return false;
   };
@@ -63,7 +64,7 @@ export function useProjectCallSheets(projectId?: string) {
       
       return callSheetWithProject;
     } catch (error) {
-      console.error("Error saving call sheet to storage:", error);
+      logger.error("Error saving call sheet to storage:", error);
       return null;
     }
   };
@@ -85,7 +86,7 @@ export function useProjectCallSheets(projectId?: string) {
       
       return true;
     } catch (error) {
-      console.error("Error deleting call sheet:", error);
+      logger.error("Error deleting call sheet:", error);
       return false;
     }
   };
@@ -106,7 +107,7 @@ export function useProjectCallSheets(projectId?: string) {
       
       return true;
     } catch (error) {
-      console.error("Error updating call sheet status:", error);
+      logger.error("Error updating call sheet status:", error);
       return false;
     }
   };

--- a/src/hooks/use-projects.ts
+++ b/src/hooks/use-projects.ts
@@ -4,6 +4,7 @@ import { useToast } from "@/hooks/use-toast";
 import type { SelectProject, InsertProject } from "@shared/schema";
 import { nanoid } from "nanoid";
 import { apiRequest } from "@/lib/api";
+import { logger } from "@shared/logger";
 
 const STORAGE_KEY = "brick-projects";
 
@@ -16,13 +17,13 @@ export function useProjects() {
   const syncData = async () => {
     try {
       // 1. Buscar dados do servidor
-      const serverProjects = await apiRequest("/api/projects");
-      console.log("Server projects:", serverProjects);
+        const serverProjects = await apiRequest("/api/projects");
+        logger.log("Server projects:", serverProjects);
       
       // 2. Buscar dados locais
       const localData = localStorage.getItem(STORAGE_KEY);
-      const localProjects: SelectProject[] = localData ? JSON.parse(localData) : [];
-      console.log("Local projects:", localProjects);
+        const localProjects: SelectProject[] = localData ? JSON.parse(localData) : [];
+        logger.log("Local projects:", localProjects);
       
       // 3. Primeiro, enviar projetos locais que não existem no servidor
       const serverIds = new Set(serverProjects.map((p: SelectProject) => p.id));
@@ -30,14 +31,14 @@ export function useProjects() {
       
       for (const localProject of localOnlyProjects) {
         try {
-          console.log("Uploading local project to server:", localProject.name);
+            logger.log("Uploading local project to server:", localProject.name);
           await apiRequest("/api/projects", {
             method: "POST",
             body: JSON.stringify(localProject),
             headers: { "Content-Type": "application/json" },
           });
         } catch (error) {
-          console.warn("Failed to upload local project:", error);
+            logger.warn("Failed to upload local project:", error);
         }
       }
       
@@ -68,7 +69,7 @@ export function useProjects() {
               method: "PUT",
               body: JSON.stringify(localProject),
               headers: { "Content-Type": "application/json" },
-            }).catch(err => console.warn("Failed to update server:", err));
+              }).catch(err => logger.warn("Failed to update server:", err));
           }
         }
       });
@@ -79,11 +80,11 @@ export function useProjects() {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(finalProjects));
       
       setLastSync(new Date());
-      console.log("Sync completed, final projects:", finalProjects);
+        logger.log("Sync completed, final projects:", finalProjects);
       return finalProjects;
       
     } catch (error) {
-      console.warn("Server sync failed, using localStorage:", error);
+        logger.warn("Server sync failed, using localStorage:", error);
       const localData = localStorage.getItem(STORAGE_KEY);
       return localData ? JSON.parse(localData) : [];
     }
@@ -114,7 +115,7 @@ export function useProjects() {
 
       // 1. Tentar salvar no servidor PRIMEIRO
       try {
-        console.log("Creating project on server:", newProject);
+          logger.log("Creating project on server:", newProject);
         const serverProject = await apiRequest("/api/projects", {
           method: "POST",
           body: JSON.stringify(newProject),
@@ -127,11 +128,11 @@ export function useProjects() {
         const updated = [...localProjects, serverProject];
         localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
         
-        console.log("Project created successfully on server and local");
+          logger.log("Project created successfully on server and local");
         return serverProject;
         
       } catch (error) {
-        console.warn("Server save failed, saving locally:", error);
+        logger.warn("Server save failed, saving locally:", error);
         
         // 3. Fallback: salvar apenas localmente
         const localData = localStorage.getItem(STORAGE_KEY);
@@ -171,7 +172,7 @@ export function useProjects() {
           headers: { "Content-Type": "application/json" },
         });
       } catch (error) {
-        console.warn("Server update failed:", error);
+        logger.warn("Server update failed:", error);
         return updated.find(p => p.id === id);
       }
     },
@@ -198,7 +199,7 @@ export function useProjects() {
           method: "DELETE",
         });
       } catch (error) {
-        console.warn("Server delete failed:", error);
+        logger.warn("Server delete failed:", error);
       }
 
       return true;
@@ -271,7 +272,7 @@ export function useProjectCallSheets(projectId?: string) {
         }
       }
     } catch (error) {
-      console.error("Error loading call sheets:", error);
+        logger.error("Error loading call sheets:", error);
     }
   }, [projectId]);
 
@@ -291,7 +292,7 @@ export function useProjectCallSheets(projectId?: string) {
           }
         }
       } catch (error) {
-        console.error("Error refreshing call sheets:", error);
+          logger.error("Error refreshing call sheets:", error);
       }
     },
   };

--- a/src/hooks/use-sync-storage.ts
+++ b/src/hooks/use-sync-storage.ts
@@ -4,6 +4,7 @@ import { useToast } from "@/hooks/use-toast";
 import type { SelectProject, InsertProject, SelectCallSheet, InsertCallSheet } from "@shared/schema";
 import { nanoid } from "nanoid";
 import { apiRequest } from "@/lib/api";
+import { logger } from "@shared/logger";
 
 const PROJECTS_STORAGE_KEY = "brick-projects";
 const CALLSHEETS_STORAGE_KEY = "brick-call-sheets";
@@ -37,7 +38,7 @@ export function useSyncProjects() {
       return mergedProjects;
       
     } catch (error) {
-      console.warn("Sync failed, using localStorage only:", error);
+      logger.warn("Sync failed, using localStorage only:", error);
       const localData = localStorage.getItem(PROJECTS_STORAGE_KEY);
       return localData ? JSON.parse(localData) : [];
     }
@@ -89,7 +90,7 @@ export function useSyncProjects() {
             headers: { "Content-Type": "application/json" },
           });
         } catch (error) {
-          console.warn(`Failed to create project ${project.id} on server:`, error);
+          logger.warn(`Failed to create project ${project.id} on server:`, error);
         }
       } else if (new Date(project.updatedAt) > new Date(serverProject.updatedAt)) {
         // Atualizar no servidor
@@ -100,7 +101,7 @@ export function useSyncProjects() {
             headers: { "Content-Type": "application/json" },
           });
         } catch (error) {
-          console.warn(`Failed to update project ${project.id} on server:`, error);
+          logger.warn(`Failed to update project ${project.id} on server:`, error);
         }
       }
     }
@@ -141,7 +142,7 @@ export function useSyncProjects() {
           headers: { "Content-Type": "application/json" },
         });
       } catch (error) {
-        console.warn("Failed to save to server, will sync later:", error);
+          logger.warn("Failed to save to server, will sync later:", error);
       }
 
       return newProject;
@@ -176,7 +177,7 @@ export function useSyncProjects() {
           headers: { "Content-Type": "application/json" },
         });
       } catch (error) {
-        console.warn("Failed to update on server, will sync later:", error);
+          logger.warn("Failed to update on server, will sync later:", error);
         return updated.find(p => p.id === id);
       }
     },
@@ -204,7 +205,7 @@ export function useSyncProjects() {
           method: "DELETE",
         });
       } catch (error) {
-        console.warn("Failed to delete from server, will sync later:", error);
+        logger.warn("Failed to delete from server, will sync later:", error);
       }
 
       return true;
@@ -283,7 +284,7 @@ export function useSyncCallSheets(projectId?: string) {
         : mergedCallSheets;
         
     } catch (error) {
-      console.warn("CallSheets sync failed:", error);
+      logger.warn("CallSheets sync failed:", error);
       const localData = localStorage.getItem(CALLSHEETS_STORAGE_KEY);
       const localCallSheets = localData ? JSON.parse(localData) : [];
       return projectId 

--- a/src/hooks/use-templates.tsx
+++ b/src/hooks/use-templates.tsx
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/api";
 import type { SelectTemplate, InsertTemplate } from "@shared/schema";
+import { logger } from "@shared/logger";
 
 export function useTemplates(category?: string) {
   return useQuery({
@@ -11,7 +12,7 @@ export function useTemplates(category?: string) {
         const data = await apiRequest(url) as SelectTemplate[];
         return data;
       } catch (error) {
-        console.warn('Erro de conexão com banco, usando armazenamento local:', error);
+          logger.warn('Erro de conexão com banco, usando armazenamento local:', error);
         return getLocalTemplates(category);
       }
     },
@@ -29,7 +30,7 @@ function getLocalTemplates(category?: string): SelectTemplate[] {
     }
     return templates;
   } catch (error) {
-    console.error('Erro ao carregar templates locais:', error);
+      logger.error('Erro ao carregar templates locais:', error);
     return [];
   }
 }
@@ -65,7 +66,7 @@ export function useCreateTemplate() {
           body: JSON.stringify(template),
         }) as SelectTemplate;
       } catch (error) {
-        console.warn('Salvando template localmente devido a erro de conexão:', error);
+          logger.warn('Salvando template localmente devido a erro de conexão:', error);
         return saveTemplateLocally(template);
       }
     },
@@ -111,7 +112,7 @@ function saveTemplateLocally(template: InsertTemplate): SelectTemplate {
     
     return newTemplate;
   } catch (error) {
-    console.error('Erro ao salvar template localmente:', error);
+      logger.error('Erro ao salvar template localmente:', error);
     throw new Error('Falha ao salvar template');
   }
 }
@@ -126,7 +127,7 @@ export function useDeleteTemplate() {
           method: 'DELETE',
         });
       } catch (error) {
-        console.warn('Deletando template localmente devido a erro de conexão:', error);
+          logger.warn('Deletando template localmente devido a erro de conexão:', error);
         return deleteTemplateLocally(id);
       }
     },
@@ -145,7 +146,7 @@ function deleteTemplateLocally(id: string): void {
     const updatedTemplates = templates.filter((t: SelectTemplate) => t.id !== id);
     localStorage.setItem('brick_templates', JSON.stringify(updatedTemplates));
   } catch (error) {
-    console.error('Erro ao deletar template localmente:', error);
+      logger.error('Erro ao deletar template localmente:', error);
     throw new Error('Falha ao deletar template');
   }
 }


### PR DESCRIPTION
## Summary
- replace scattered `console.*` calls with shared `logger` helper driven by `NODE_ENV`
- remove leftover debugging log from `server/delete.test.ts`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6892780dccbc832caad5445e9ce5a9aa