### PR TITLE
skip initial call sheet unsaved tracking

### DIFF
--- a/src/hooks/use-call-sheet.test.tsx
+++ b/src/hooks/use-call-sheet.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useCallSheet } from "./use-call-sheet";
+
+const STORAGE_KEY = "brick-call-sheet";
+
+const storedSheet = {
+  id: "stored-id",
+  productionTitle: "Stored Title",
+  shootingDate: "2024-01-01",
+  producer: "",
+  director: "",
+  client: "",
+  scriptUrl: "",
+  scriptName: "",
+  attachments: [],
+  startTime: "",
+  lunchBreakTime: "",
+  endTime: "",
+  locations: [],
+  scenes: [],
+  contacts: [],
+  crewCallTimes: [],
+  castCallTimes: [],
+  generalNotes: "",
+};
+
+describe("useCallSheet initial load", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("loads from localStorage without unsaved changes", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(storedSheet));
+    const { result } = renderHook(() => useCallSheet());
+
+    await waitFor(() =>
+      expect(result.current.callSheet.productionTitle).toBe("Stored Title")
+    );
+    expect(result.current.hasUnsavedChanges).toBe(false);
+  });
+
+  it("marks unsaved changes after updates", async () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(storedSheet));
+    const { result } = renderHook(() => useCallSheet());
+
+    await waitFor(() =>
+      expect(result.current.callSheet.productionTitle).toBe("Stored Title")
+    );
+
+    act(() => {
+      result.current.updateField("productionTitle", "New Title");
+    });
+
+    expect(result.current.hasUnsavedChanges).toBe(true);
+  });
+});

--- a/src/hooks/use-call-sheet.tsx
+++ b/src/hooks/use-call-sheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { CallSheet, Location, Scene, Contact, CallTime, Attachment } from "@shared/schema";
 import { nanoid } from "nanoid";
 
@@ -27,12 +27,17 @@ export function useCallSheet() {
   });
 
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+  const skipEffect = useRef(1);
 
   useEffect(() => {
     loadFromStorage();
   }, []);
 
   useEffect(() => {
+    if (skipEffect.current > 0) {
+      skipEffect.current -= 1;
+      return;
+    }
     setHasUnsavedChanges(true);
   }, [callSheet]);
 
@@ -261,6 +266,7 @@ export function useCallSheet() {
       const stored = localStorage.getItem(STORAGE_KEY);
       if (stored) {
         const parsed = JSON.parse(stored);
+        skipEffect.current += 1;
         setCallSheet(parsed);
         setHasUnsavedChanges(false);
         return true;
@@ -268,6 +274,7 @@ export function useCallSheet() {
     } catch (error) {
       console.error("Error loading from storage:", error);
     }
+    setHasUnsavedChanges(false);
     return false;
   };
 


### PR DESCRIPTION
## Summary
- prevent hasUnsavedChanges from toggling during initial load by skipping first effect runs
- ensure loadFromStorage resets hasUnsavedChanges and avoid triggering unsaved state
- add unit tests covering initial load and subsequent updates

## Testing
- `npm test`
- `npx vitest run src/hooks/use-call-sheet.test.tsx src/hooks/use-projects.test.tsx --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_689645f3f658832ca0f8b29dbdb7c2f0