### PR TITLE
refactor: centralize default call sheet

### DIFF
--- a/src/hooks/use-call-sheet.test.tsx
+++ b/src/hooks/use-call-sheet.test.tsx
@@ -1,28 +1,14 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
-import { useCallSheet } from "./use-call-sheet";
+import { useCallSheet, DEFAULT_CALL_SHEET } from "./use-call-sheet";
 
 const STORAGE_KEY = "brick-call-sheet";
 
 const storedSheet = {
   id: "stored-id",
+  ...DEFAULT_CALL_SHEET,
   productionTitle: "Stored Title",
   shootingDate: "2024-01-01",
-  producer: "",
-  director: "",
-  client: "",
-  scriptUrl: "",
-  scriptName: "",
-  attachments: [],
-  startTime: "",
-  lunchBreakTime: "",
-  endTime: "",
-  locations: [],
-  scenes: [],
-  contacts: [],
-  crewCallTimes: [],
-  castCallTimes: [],
-  generalNotes: "",
 };
 
 describe("useCallSheet initial load", () => {

--- a/src/hooks/use-call-sheet.tsx
+++ b/src/hooks/use-call-sheet.tsx
@@ -4,26 +4,30 @@ import { nanoid } from "nanoid";
 
 const STORAGE_KEY = "brick-call-sheet";
 
+export const DEFAULT_CALL_SHEET: Omit<CallSheet, "id"> = {
+  productionTitle: "",
+  shootingDate: "",
+  producer: "",
+  director: "",
+  client: "",
+  scriptUrl: "",
+  scriptName: "",
+  attachments: [],
+  startTime: "",
+  lunchBreakTime: "",
+  endTime: "",
+  locations: [],
+  scenes: [],
+  contacts: [],
+  crewCallTimes: [],
+  castCallTimes: [],
+  generalNotes: "",
+};
+
 export function useCallSheet() {
   const [callSheet, setCallSheet] = useState<CallSheet>({
     id: nanoid(),
-    productionTitle: "",
-    shootingDate: "",
-    producer: "",
-    director: "",
-    client: "",
-    scriptUrl: "",
-    scriptName: "",
-    attachments: [],
-    startTime: "",
-    lunchBreakTime: "",
-    endTime: "",
-    locations: [],
-    scenes: [],
-    contacts: [],
-    crewCallTimes: [],
-    castCallTimes: [],
-    generalNotes: "",
+    ...DEFAULT_CALL_SHEET,
   });
 
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
@@ -281,23 +285,7 @@ export function useCallSheet() {
   const clearData = () => {
     setCallSheet({
       id: nanoid(),
-      productionTitle: "",
-      shootingDate: "",
-      producer: "",
-      director: "",
-      client: "",
-      scriptUrl: "",
-      scriptName: "",
-      attachments: [],
-      startTime: "",
-      lunchBreakTime: "",
-      endTime: "",
-      locations: [],
-      scenes: [],
-      contacts: [],
-      crewCallTimes: [],
-      castCallTimes: [],
-      generalNotes: "",
+      ...DEFAULT_CALL_SHEET,
     });
     setHasUnsavedChanges(false);
   };


### PR DESCRIPTION
## Summary
- centralize call sheet default values in a shared constant
- reuse default state in hook and tests to avoid duplication

## Testing
- `npm test`
- `npx vitest run src/hooks/use-call-sheet.test.tsx --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_689647b4c368832cadb6dab896150839