### PR TITLE
Switch templates.is_default to boolean

### DIFF
--- a/migrations/0001_change_is_default_type.sql
+++ b/migrations/0001_change_is_default_type.sql
@@ -1,0 +1,7 @@
+-- Change is_default column from json to boolean with default false
+ALTER TABLE templates
+  ALTER COLUMN is_default TYPE boolean USING (is_default::boolean);
+ALTER TABLE templates
+  ALTER COLUMN is_default SET DEFAULT false;
+ALTER TABLE templates
+  ALTER COLUMN is_default SET NOT NULL;

--- a/server/memory-storage.ts
+++ b/server/memory-storage.ts
@@ -74,7 +74,7 @@ export class MemoryStorage implements IStorage {
     const newTemplate: SelectTemplate = {
       ...template,
       id: template.id || nanoid(),
-      isDefault: template.isDefault || false,
+      isDefault: template.isDefault ?? false,
       createdAt: now,
       updatedAt: now,
     };

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { pgTable, text, timestamp, json } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, json, boolean } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 
 // Zod schemas for frontend validation
@@ -150,7 +150,7 @@ export const templates = pgTable('templates', {
   name: text('name').notNull(),
   description: text('description').notNull(),
   category: text('category').notNull(),
-  isDefault: json('is_default').$type<boolean>().notNull().default(false as any),
+  isDefault: boolean('is_default').notNull().default(false),
   templateData: json('template_data').$type<{
     productionTitle?: string;
     producer?: string;

--- a/src/components/use-templates-netlify.tsx
+++ b/src/components/use-templates-netlify.tsx
@@ -48,7 +48,7 @@ export function useCreateTemplate() {
       const newTemplate: SelectTemplate = {
         ...template,
         id: `local_${Date.now()}`,
-        isDefault: Boolean(template.isDefault || false),
+        isDefault: template.isDefault ?? false,
         createdAt: new Date(),
         updatedAt: new Date(),
       };

--- a/src/hooks/use-templates.tsx
+++ b/src/hooks/use-templates.tsx
@@ -101,7 +101,7 @@ function saveTemplateLocally(template: InsertTemplate): SelectTemplate {
     const newTemplate: SelectTemplate = {
       ...template,
       id: `local_${Date.now()}`,
-      isDefault: template.isDefault || false,
+      isDefault: template.isDefault ?? false,
       createdAt: new Date(),
       updatedAt: new Date(),
     };


### PR DESCRIPTION
## Summary
- store template `is_default` as boolean with default false
- update codepaths and memory storage to use boolean flags
- add migration converting `is_default` column to boolean

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689647f3bdbc832cbfa08d0d0678158b