### PR TITLE
Refactor storages to use generic repositories

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview",
     "db:push": "drizzle-kit push",
     "start": "tsx server/index.ts",
-    "test": "tsx --test server/routes.test.ts"
+    "test": "tsx --test server/*.test.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.1.0",

--- a/server/delete.test.ts
+++ b/server/delete.test.ts
@@ -1,7 +1,8 @@
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { DatabaseStorage } from './database-storage';
 
-async function run() {
+test('deletion operations', async () => {
   const storage = new DatabaseStorage();
 
   const callSheet = await storage.createCallSheet({
@@ -36,8 +37,4 @@ async function run() {
 
   const member = await storage.createTeamMember({ name: 'M' });
   assert.equal(await storage.deleteTeamMember(member.id), true);
-
-  console.log('Deletion tests passed');
-}
-
-run();
+});

--- a/server/memory-storage.ts
+++ b/server/memory-storage.ts
@@ -1,4 +1,3 @@
-import { nanoid } from "nanoid";
 import {
   type SelectCallSheet,
   type InsertCallSheet,
@@ -10,194 +9,135 @@ import {
   type InsertTeamMember,
 } from "@shared/schema";
 import type { IStorage } from "./storage";
+import {
+  createMemoryRepository,
+  prepareCallSheetCreate,
+  prepareCallSheetUpdate,
+  prepareTemplateCreate,
+  prepareTemplateUpdate,
+  prepareProjectCreate,
+  prepareProjectUpdate,
+  prepareTeamMemberCreate,
+  prepareTeamMemberUpdate,
+} from "./repository";
 
 export class MemoryStorage implements IStorage {
-  private callSheets: SelectCallSheet[] = [];
-  private templates: SelectTemplate[] = [];
-  private projects: SelectProject[] = [];
-  private teamMembers: SelectTeamMember[] = [];
+  private callSheetsRepo = createMemoryRepository<SelectCallSheet, InsertCallSheet>(
+    prepareCallSheetCreate,
+    (existing, updates) => ({
+      ...existing,
+      ...prepareCallSheetUpdate(updates),
+    }),
+  );
+  private templatesRepo = createMemoryRepository<SelectTemplate, InsertTemplate>(
+    prepareTemplateCreate,
+    (existing, updates) => ({
+      ...existing,
+      ...prepareTemplateUpdate(updates),
+    }),
+  );
+  private projectsRepo = createMemoryRepository<SelectProject, InsertProject>(
+    prepareProjectCreate,
+    (existing, updates) => ({
+      ...existing,
+      ...prepareProjectUpdate(updates),
+    }),
+  );
+  private teamMembersRepo = createMemoryRepository<SelectTeamMember, InsertTeamMember>(
+    prepareTeamMemberCreate,
+    (existing, updates) => ({
+      ...existing,
+      ...prepareTeamMemberUpdate(updates),
+    }),
+  );
 
-  async getCallSheet(id: string): Promise<SelectCallSheet | undefined> {
-    return this.callSheets.find(cs => cs.id === id);
+  async getCallSheet(id: string) {
+    return this.callSheetsRepo.get(id);
   }
 
-  async createCallSheet(callSheet: InsertCallSheet): Promise<SelectCallSheet> {
-    const now = new Date();
-    const newCallSheet: SelectCallSheet = {
-      ...callSheet,
-      id: callSheet.id || nanoid(),
-      locations: callSheet.locations || [],
-      scenes: callSheet.scenes || [],
-      contacts: callSheet.contacts || [],
-      crewCallTimes: callSheet.crewCallTimes || [],
-      castCallTimes: callSheet.castCallTimes || [],
-      generalNotes: callSheet.generalNotes || '',
-      createdAt: now,
-      updatedAt: now,
-    };
-
-    this.callSheets.push(newCallSheet);
-    return newCallSheet;
+  async createCallSheet(callSheet: InsertCallSheet) {
+    return this.callSheetsRepo.create(callSheet);
   }
 
-  async updateCallSheet(id: string, updates: Partial<InsertCallSheet>): Promise<SelectCallSheet | undefined> {
-    const index = this.callSheets.findIndex(cs => cs.id === id);
-    if (index === -1) return undefined;
-
-    this.callSheets[index] = {
-      ...this.callSheets[index],
-      ...updates,
-      updatedAt: new Date(),
-    };
-
-    return this.callSheets[index];
+  async updateCallSheet(id: string, updates: Partial<InsertCallSheet>) {
+    return this.callSheetsRepo.update(id, updates);
   }
 
-  async deleteCallSheet(id: string): Promise<boolean> {
-    const index = this.callSheets.findIndex(cs => cs.id === id);
-    if (index === -1) return false;
-
-    this.callSheets.splice(index, 1);
-    return true;
+  async deleteCallSheet(id: string) {
+    return this.callSheetsRepo.delete(id);
   }
 
-  async listCallSheets(): Promise<SelectCallSheet[]> {
-    return [...this.callSheets];
+  async listCallSheets() {
+    return this.callSheetsRepo.list();
   }
 
-  async getTemplate(id: string): Promise<SelectTemplate | undefined> {
-    return this.templates.find(t => t.id === id);
+  async getTemplate(id: string) {
+    return this.templatesRepo.get(id);
   }
 
-  async createTemplate(template: InsertTemplate): Promise<SelectTemplate> {
-    const now = new Date();
-    const newTemplate: SelectTemplate = {
-      ...template,
-      id: template.id || nanoid(),
-      isDefault: template.isDefault ?? false,
-      createdAt: now,
-      updatedAt: now,
-    };
-
-    this.templates.push(newTemplate);
-    return newTemplate;
+  async createTemplate(template: InsertTemplate) {
+    return this.templatesRepo.create(template);
   }
 
-  async updateTemplate(id: string, updates: Partial<InsertTemplate>): Promise<SelectTemplate | undefined> {
-    const index = this.templates.findIndex(t => t.id === id);
-    if (index === -1) return undefined;
-
-    this.templates[index] = {
-      ...this.templates[index],
-      ...updates,
-      updatedAt: new Date(),
-    };
-
-    return this.templates[index];
+  async updateTemplate(id: string, updates: Partial<InsertTemplate>) {
+    return this.templatesRepo.update(id, updates);
   }
 
-  async deleteTemplate(id: string): Promise<boolean> {
-    const index = this.templates.findIndex(t => t.id === id);
-    if (index === -1) return false;
-
-    this.templates.splice(index, 1);
-    return true;
+  async deleteTemplate(id: string) {
+    return this.templatesRepo.delete(id);
   }
 
-  async listTemplates(): Promise<SelectTemplate[]> {
-    return [...this.templates];
+  async listTemplates() {
+    return this.templatesRepo.list();
   }
 
-  async getTemplatesByCategory(category: string): Promise<SelectTemplate[]> {
-    return this.templates.filter(t => t.category === category);
+  async getTemplatesByCategory(category: string) {
+    const all = await this.templatesRepo.list();
+    return all.filter((t) => t.category === category);
   }
 
-  async getDefaultTemplates(): Promise<SelectTemplate[]> {
-    return this.templates.filter(t => t.isDefault);
+  async getDefaultTemplates() {
+    const all = await this.templatesRepo.list();
+    return all.filter((t) => t.isDefault);
   }
 
-  // Project operations
-  async getProject(id: string): Promise<SelectProject | undefined> {
-    return this.projects.find(p => p.id === id);
+  async getProject(id: string) {
+    return this.projectsRepo.get(id);
   }
 
-  async createProject(project: InsertProject): Promise<SelectProject> {
-    const now = new Date();
-    const newProject: SelectProject = {
-      ...project,
-      id: project.id || nanoid(),
-      description: project.description || '',
-      client: project.client || '',
-      status: project.status || 'ativo',
-      createdAt: now,
-      updatedAt: now,
-    };
-
-    this.projects.push(newProject);
-    return newProject;
+  async createProject(project: InsertProject) {
+    return this.projectsRepo.create(project);
   }
 
-  async updateProject(id: string, updates: Partial<InsertProject>): Promise<SelectProject | undefined> {
-    const index = this.projects.findIndex(p => p.id === id);
-    if (index === -1) return undefined;
-
-    this.projects[index] = {
-      ...this.projects[index],
-      ...updates,
-      updatedAt: new Date(),
-    };
-
-    return this.projects[index];
+  async updateProject(id: string, updates: Partial<InsertProject>) {
+    return this.projectsRepo.update(id, updates);
   }
 
-  async deleteProject(id: string): Promise<boolean> {
-    const index = this.projects.findIndex(p => p.id === id);
-    if (index === -1) return false;
-
-    this.projects.splice(index, 1);
-    return true;
+  async deleteProject(id: string) {
+    return this.projectsRepo.delete(id);
   }
 
-  async listProjects(): Promise<SelectProject[]> {
-    return [...this.projects];
+  async listProjects() {
+    return this.projectsRepo.list();
   }
 
-  // Team member operations
-  async getTeamMember(id: string): Promise<SelectTeamMember | undefined> {
-    return this.teamMembers.find(tm => tm.id === id);
+  async getTeamMember(id: string) {
+    return this.teamMembersRepo.get(id);
   }
 
-  async createTeamMember(teamMember: InsertTeamMember): Promise<SelectTeamMember> {
-    const now = new Date();
-    const newMember: SelectTeamMember = {
-      ...teamMember,
-      id: teamMember.id || nanoid(),
-      createdAt: now,
-      updatedAt: now,
-    } as SelectTeamMember;
-    this.teamMembers.push(newMember);
-    return newMember;
+  async createTeamMember(teamMember: InsertTeamMember) {
+    return this.teamMembersRepo.create(teamMember);
   }
 
-  async updateTeamMember(id: string, updates: Partial<InsertTeamMember>): Promise<SelectTeamMember | undefined> {
-    const index = this.teamMembers.findIndex(tm => tm.id === id);
-    if (index === -1) return undefined;
-    this.teamMembers[index] = {
-      ...this.teamMembers[index],
-      ...updates,
-      updatedAt: new Date(),
-    } as SelectTeamMember;
-    return this.teamMembers[index];
+  async updateTeamMember(id: string, updates: Partial<InsertTeamMember>) {
+    return this.teamMembersRepo.update(id, updates);
   }
 
-  async deleteTeamMember(id: string): Promise<boolean> {
-    const index = this.teamMembers.findIndex(tm => tm.id === id);
-    if (index === -1) return false;
-    this.teamMembers.splice(index, 1);
-    return true;
+  async deleteTeamMember(id: string) {
+    return this.teamMembersRepo.delete(id);
   }
 
-  async listTeamMembers(): Promise<SelectTeamMember[]> {
-    return [...this.teamMembers];
+  async listTeamMembers() {
+    return this.teamMembersRepo.list();
   }
 }

--- a/server/repository.test.ts
+++ b/server/repository.test.ts
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createMemoryRepository } from "./repository";
+
+interface Item {
+  id: string;
+  name: string;
+}
+
+interface InsertItem {
+  id?: string;
+  name: string;
+}
+
+test("memory repository CRUD", async () => {
+  let counter = 0;
+  const repo = createMemoryRepository<Item, InsertItem>(
+    (data) => ({ id: data.id ?? String(counter++), name: data.name }),
+    (existing, updates) => ({ ...existing, ...updates }),
+  );
+
+  const created = await repo.create({ name: "A" });
+  assert.equal(created.name, "A");
+
+  const fetched = await repo.get(created.id);
+  assert.deepEqual(fetched, created);
+
+  const updated = await repo.update(created.id, { name: "B" });
+  assert.equal(updated?.name, "B");
+
+  const list = await repo.list();
+  assert.equal(list.length, 1);
+
+  const deleted = await repo.delete(created.id);
+  assert.equal(deleted, true);
+  assert.equal(await repo.get(created.id), undefined);
+});

--- a/server/repository.ts
+++ b/server/repository.ts
@@ -1,0 +1,210 @@
+import { nanoid } from "nanoid";
+import { db } from "./db";
+import { eq } from "drizzle-orm";
+import type {
+  SelectCallSheet,
+  InsertCallSheet,
+  SelectTemplate,
+  InsertTemplate,
+  SelectProject,
+  InsertProject,
+  SelectTeamMember,
+  InsertTeamMember,
+} from "@shared/schema";
+
+export interface CrudRepository<T, InsertT> {
+  get(id: string): Promise<T | undefined>;
+  create(data: InsertT): Promise<T>;
+  update(id: string, updates: Partial<InsertT>): Promise<T | undefined>;
+  delete(id: string): Promise<boolean>;
+  list(): Promise<T[]>;
+}
+
+export function createMemoryRepository<T extends { id: string }, InsertT>(
+  prepareCreate: (data: InsertT) => T,
+  prepareUpdate: (existing: T, updates: Partial<InsertT>) => T,
+): CrudRepository<T, InsertT> {
+  const items: T[] = [];
+  return {
+    async get(id: string) {
+      return items.find((i) => i.id === id);
+    },
+    async create(data: InsertT) {
+      const entity = prepareCreate(data);
+      items.push(entity);
+      return entity;
+    },
+    async update(id: string, updates: Partial<InsertT>) {
+      const index = items.findIndex((i) => i.id === id);
+      if (index === -1) return undefined;
+      items[index] = prepareUpdate(items[index], updates);
+      return items[index];
+    },
+    async delete(id: string) {
+      const index = items.findIndex((i) => i.id === id);
+      if (index === -1) return false;
+      items.splice(index, 1);
+      return true;
+    },
+    async list() {
+      return [...items];
+    },
+  };
+}
+
+export function createDatabaseRepository<T extends { id: string }, InsertT>(
+  table: any,
+  prepareCreate: (data: InsertT) => any,
+  prepareUpdate: (updates: Partial<InsertT>) => any,
+): CrudRepository<T, InsertT> {
+  return {
+    async get(id: string) {
+      const [row] = await db.select().from(table).where(eq(table.id, id));
+      return row || undefined;
+    },
+    async create(data: InsertT) {
+      const record = prepareCreate(data);
+      const [created] = await db.insert(table).values([record]).returning();
+      return created;
+    },
+    async update(id: string, updates: Partial<InsertT>) {
+      const updateData = prepareUpdate(updates);
+      const [updated] = await db
+        .update(table)
+        .set(updateData)
+        .where(eq(table.id, id))
+        .returning();
+      return updated || undefined;
+    },
+    async delete(id: string) {
+      const result = await db
+        .delete(table)
+        .where(eq(table.id, id))
+        .returning({ id: table.id });
+      return result.length > 0;
+    },
+    async list() {
+      return await db.select().from(table);
+    },
+  };
+}
+
+export function withFallback<T, InsertT>(
+  repo: CrudRepository<T, InsertT>,
+  fallback: CrudRepository<T, InsertT>,
+): CrudRepository<T, InsertT> {
+  return {
+    async get(id: string) {
+      try {
+        return await repo.get(id);
+      } catch (error: any) {
+        console.warn("Database error, using fallback:", error.message);
+        return fallback.get(id);
+      }
+    },
+    async create(data: InsertT) {
+      try {
+        return await repo.create(data);
+      } catch (error: any) {
+        console.warn("Database error, using fallback:", error.message);
+        return fallback.create(data);
+      }
+    },
+    async update(id: string, updates: Partial<InsertT>) {
+      try {
+        return await repo.update(id, updates);
+      } catch (error: any) {
+        console.warn("Database error, using fallback:", error.message);
+        return fallback.update(id, updates);
+      }
+    },
+    async delete(id: string) {
+      try {
+        return await repo.delete(id);
+      } catch (error: any) {
+        console.warn("Database error, using fallback:", error.message);
+        return fallback.delete(id);
+      }
+    },
+    async list() {
+      try {
+        return await repo.list();
+      } catch (error: any) {
+        console.warn("Database error, using fallback:", error.message);
+        return fallback.list();
+      }
+    },
+  };
+}
+
+// Preparation helpers for entities
+export function prepareCallSheetCreate(callSheet: InsertCallSheet): SelectCallSheet {
+  const now = new Date();
+  return {
+    ...callSheet,
+    id: callSheet.id || nanoid(),
+    locations: Array.from(callSheet.locations || []),
+    scenes: Array.from(callSheet.scenes || []),
+    contacts: Array.from(callSheet.contacts || []),
+    crewCallTimes: Array.from(callSheet.crewCallTimes || []),
+    castCallTimes: Array.from(callSheet.castCallTimes || []),
+    generalNotes: callSheet.generalNotes || "",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function prepareCallSheetUpdate(
+  updates: Partial<InsertCallSheet>,
+) {
+  return { ...updates, updatedAt: new Date() };
+}
+
+export function prepareTemplateCreate(template: InsertTemplate): SelectTemplate {
+  const now = new Date();
+  return {
+    ...template,
+    id: template.id || nanoid(),
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function prepareTemplateUpdate(updates: Partial<InsertTemplate>) {
+  return { ...updates, updatedAt: new Date() };
+}
+
+export function prepareProjectCreate(project: InsertProject): SelectProject {
+  const now = new Date();
+  return {
+    ...project,
+    id: project.id || nanoid(),
+    description: project.description || "",
+    client: project.client || "",
+    status: project.status || "ativo",
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+export function prepareProjectUpdate(updates: Partial<InsertProject>) {
+  return { ...updates, updatedAt: new Date() };
+}
+
+export function prepareTeamMemberCreate(
+  teamMember: InsertTeamMember,
+): SelectTeamMember {
+  const now = new Date();
+  return {
+    ...teamMember,
+    id: teamMember.id || nanoid(),
+    createdAt: now,
+    updatedAt: now,
+  } as SelectTeamMember;
+}
+
+export function prepareTeamMemberUpdate(
+  updates: Partial<InsertTeamMember>,
+) {
+  return { ...updates, updatedAt: new Date() };
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -9,7 +9,6 @@ import type {
   InsertTeamMember,
 } from "@shared/schema";
 import { DatabaseStorage } from "./database-storage";
-import { MemoryStorage } from "./memory-storage";
 
 export interface IStorage {
   // Call sheet operations
@@ -44,7 +43,7 @@ export interface IStorage {
 }
 
 export function createStorage(): IStorage {
-  return new DatabaseStorage(new MemoryStorage());
+  return new DatabaseStorage();
 }
 
 export const storage = createStorage();


### PR DESCRIPTION
## Summary
- add generic repository utilities for CRUD and fallback support
- refactor MemoryStorage and DatabaseStorage to delegate to repositories
- cover new abstraction with unit tests and updated test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964bba4f80832cb897a0961ee7997e