### PR TITLE
feat: add ids for form inputs

### DIFF
--- a/src/components/call-times-section.tsx
+++ b/src/components/call-times-section.tsx
@@ -58,10 +58,14 @@ export default function CallTimesSection({
         {/* Horários Gerais */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6 p-4 bg-muted rounded-lg">
           <div>
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="call-start-time"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Horário de Início
             </Label>
             <Input
+              id="call-start-time"
               type="time"
               value={startTime || ''}
               onChange={(e) => onUpdateField('startTime', e.target.value)}
@@ -69,10 +73,14 @@ export default function CallTimesSection({
             />
           </div>
           <div>
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="call-lunch-break-time"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Horário do Almoço
             </Label>
             <Input
+              id="call-lunch-break-time"
               type="time"
               value={lunchBreakTime || ''}
               onChange={(e) => onUpdateField('lunchBreakTime', e.target.value)}
@@ -80,10 +88,14 @@ export default function CallTimesSection({
             />
           </div>
           <div>
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="call-end-time"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Horário de Fim
             </Label>
             <Input
+              id="call-end-time"
               type="time"
               value={endTime || ''}
               onChange={(e) => onUpdateField('endTime', e.target.value)}
@@ -119,7 +131,12 @@ export default function CallTimesSection({
                   <div key={callTime.id} className="space-y-2 p-3 bg-muted rounded-lg">
                     <div className="flex items-start justify-between">
                       <div className="w-full mr-2">
-                        <Label className="text-xs text-muted-foreground mb-1 block">Membro da Equipe</Label>
+                        <Label
+                          htmlFor={`crew-member-${callTime.id}`}
+                          className="text-xs text-muted-foreground mb-1 block"
+                        >
+                          Membro da Equipe
+                        </Label>
                         <Select
                           value={callTime.memberId || undefined}
                           onValueChange={(value) => {
@@ -136,7 +153,10 @@ export default function CallTimesSection({
                             }
                           }}
                         >
-                          <SelectTrigger className="w-full px-3 py-2 text-sm">
+                          <SelectTrigger
+                            id={`crew-member-${callTime.id}`}
+                            className="w-full px-3 py-2 text-sm"
+                          >
                             <SelectValue placeholder="Selecione um membro" />
                           </SelectTrigger>
                           <SelectContent>
@@ -158,8 +178,14 @@ export default function CallTimesSection({
                     </div>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                       <div>
-                        <Label className="text-xs text-muted-foreground mb-1 block">Nome</Label>
+                        <Label
+                          htmlFor={`crew-name-${callTime.id}`}
+                          className="text-xs text-muted-foreground mb-1 block"
+                        >
+                          Nome
+                        </Label>
                         <Input
+                          id={`crew-name-${callTime.id}`}
                           type="text"
                           value={callTime.name}
                           onChange={(e) => onUpdateCrew(callTime.id, { name: e.target.value })}
@@ -167,8 +193,14 @@ export default function CallTimesSection({
                         />
                       </div>
                       <div>
-                        <Label className="text-xs text-muted-foreground mb-1 block">Cargo</Label>
+                        <Label
+                          htmlFor={`crew-role-${callTime.id}`}
+                          className="text-xs text-muted-foreground mb-1 block"
+                        >
+                          Cargo
+                        </Label>
                         <Input
+                          id={`crew-role-${callTime.id}`}
                           type="text"
                           value={callTime.role}
                           onChange={(e) => onUpdateCrew(callTime.id, { role: e.target.value })}
@@ -176,8 +208,14 @@ export default function CallTimesSection({
                         />
                       </div>
                       <div>
-                        <Label className="text-xs text-muted-foreground mb-1 block">Telefone</Label>
+                        <Label
+                          htmlFor={`crew-phone-${callTime.id}`}
+                          className="text-xs text-muted-foreground mb-1 block"
+                        >
+                          Telefone
+                        </Label>
                         <Input
+                          id={`crew-phone-${callTime.id}`}
                           type="tel"
                           value={callTime.phone || ''}
                           onChange={(e) => onUpdateCrew(callTime.id, { phone: e.target.value })}
@@ -185,8 +223,14 @@ export default function CallTimesSection({
                         />
                       </div>
                       <div>
-                        <Label className="text-xs text-muted-foreground mb-1 block">Horário</Label>
+                        <Label
+                          htmlFor={`crew-time-${callTime.id}`}
+                          className="text-xs text-muted-foreground mb-1 block"
+                        >
+                          Horário
+                        </Label>
                         <Input
+                          id={`crew-time-${callTime.id}`}
                           type="time"
                           value={callTime.time}
                           onChange={(e) => onUpdateCrew(callTime.id, { time: e.target.value })}

--- a/src/components/contacts-section.tsx
+++ b/src/components/contacts-section.tsx
@@ -82,10 +82,14 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
       </div>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
-          <Label className="block text-sm font-medium text-muted-foreground mb-1">
+          <Label
+            htmlFor={`contact-${contact.id}-name`}
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
             Nome
           </Label>
           <Input
+            id={`contact-${contact.id}-name`}
             type="text"
             value={contact.name}
             onChange={(e) => onUpdate(contact.id, { name: e.target.value })}
@@ -93,10 +97,14 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
           />
         </div>
         <div>
-          <Label className="block text-sm font-medium text-muted-foreground mb-1">
+          <Label
+            htmlFor={`contact-${contact.id}-role`}
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
             Cargo/Função
           </Label>
           <Input
+            id={`contact-${contact.id}-role`}
             type="text"
             value={contact.role}
             onChange={(e) => onUpdate(contact.id, { role: e.target.value })}
@@ -104,10 +112,14 @@ function SortableContactItem({ contact, index, onUpdate, onRemove }: SortableCon
           />
         </div>
         <div>
-          <Label className="block text-sm font-medium text-muted-foreground mb-1">
+          <Label
+            htmlFor={`contact-${contact.id}-phone`}
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
             Telefone
           </Label>
           <Input
+            id={`contact-${contact.id}-phone`}
             type="tel"
             value={contact.phone}
             onChange={(e) => onUpdate(contact.id, { phone: e.target.value })}

--- a/src/components/locations-section.tsx
+++ b/src/components/locations-section.tsx
@@ -82,10 +82,14 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <Label className="block text-sm font-medium text-muted-foreground mb-1">
+          <Label
+            htmlFor={`location-${location.id}-address`}
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
             Endereço
           </Label>
           <Input
+            id={`location-${location.id}-address`}
             type="text"
             value={location.address}
             onChange={(e) => onUpdate(location.id, { address: e.target.value })}
@@ -93,10 +97,14 @@ function SortableLocationItem({ location, index, onUpdate, onRemove }: SortableL
           />
         </div>
         <div>
-          <Label className="block text-sm font-medium text-muted-foreground mb-1">
+          <Label
+            htmlFor={`location-${location.id}-notes`}
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
             Observações
           </Label>
           <Input
+            id={`location-${location.id}-notes`}
             type="text"
             value={location.notes || ''}
             onChange={(e) => onUpdate(location.id, { notes: e.target.value })}

--- a/src/components/production-info.tsx
+++ b/src/components/production-info.tsx
@@ -32,10 +32,14 @@ export default function ProductionInfo({
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div className="md:col-span-2">
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="production-client"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Cliente
             </Label>
             <Input
+              id="production-client"
               type="text"
               value={client}
               onChange={(e) => onUpdateField('client', e.target.value)}
@@ -44,10 +48,14 @@ export default function ProductionInfo({
             />
           </div>
           <div>
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="production-title"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Título da Produção
             </Label>
             <Input
+              id="production-title"
               type="text"
               value={productionTitle}
               onChange={(e) => onUpdateField('productionTitle', e.target.value)}
@@ -56,10 +64,14 @@ export default function ProductionInfo({
             />
           </div>
           <div>
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="production-shooting-date"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Data de Filmagem
             </Label>
             <Input
+              id="production-shooting-date"
               type="date"
               value={shootingDate}
               onChange={(e) => onUpdateField('shootingDate', e.target.value)}
@@ -67,10 +79,14 @@ export default function ProductionInfo({
             />
           </div>
           <div>
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="production-producer"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Produtor
             </Label>
             <Input
+              id="production-producer"
               type="text"
               value={producer}
               onChange={(e) => onUpdateField('producer', e.target.value)}
@@ -79,10 +95,14 @@ export default function ProductionInfo({
             />
           </div>
           <div>
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="production-director"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Diretor
             </Label>
             <Input
+              id="production-director"
               type="text"
               value={director}
               onChange={(e) => onUpdateField('director', e.target.value)}

--- a/src/components/scenes-section.tsx
+++ b/src/components/scenes-section.tsx
@@ -83,10 +83,14 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
       </div>
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div>
-          <Label className="block text-sm font-medium text-muted-foreground mb-1">
+          <Label
+            htmlFor={`scene-${scene.id}-number`}
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
             Número da Cena
           </Label>
           <Input
+            id={`scene-${scene.id}-number`}
             type="text"
             value={scene.number}
             onChange={(e) => onUpdate(scene.id, { number: e.target.value })}
@@ -94,10 +98,14 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
           />
         </div>
         <div className="md:col-span-2">
-          <Label className="block text-sm font-medium text-muted-foreground mb-1">
+          <Label
+            htmlFor={`scene-${scene.id}-description`}
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
             Descrição
           </Label>
           <Input
+            id={`scene-${scene.id}-description`}
             type="text"
             value={scene.description}
             onChange={(e) => onUpdate(scene.id, { description: e.target.value })}
@@ -105,10 +113,14 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
           />
         </div>
         <div>
-          <Label className="block text-sm font-medium text-muted-foreground mb-1">
+          <Label
+            htmlFor={`scene-${scene.id}-estimated-time`}
+            className="block text-sm font-medium text-muted-foreground mb-1"
+          >
             Tempo Estimado
           </Label>
           <Input
+            id={`scene-${scene.id}-estimated-time`}
             type="text"
             value={scene.estimatedTime || ''}
             onChange={(e) => onUpdate(scene.id, { estimatedTime: e.target.value })}
@@ -117,10 +129,14 @@ function SortableSceneItem({ scene, index, onUpdate, onRemove }: SortableSceneIt
         </div>
       </div>
       <div className="mt-4">
-        <Label className="block text-sm font-medium text-muted-foreground mb-1">
+        <Label
+          htmlFor={`scene-${scene.id}-cast`}
+          className="block text-sm font-medium text-muted-foreground mb-1"
+        >
           Elenco da Cena
         </Label>
         <Textarea
+          id={`scene-${scene.id}-cast`}
           value={scene.cast}
           onChange={(e) => onUpdate(scene.id, { cast: e.target.value })}
           placeholder="Liste os atores necessários para esta cena"

--- a/src/components/script-section.tsx
+++ b/src/components/script-section.tsx
@@ -215,10 +215,14 @@ export default function ScriptSection({
 
         {scriptUrl && (
           <div className="mt-4">
-            <Label className="block text-sm font-medium text-muted-foreground mb-2">
+            <Label
+              htmlFor="script-name"
+              className="block text-sm font-medium text-muted-foreground mb-2"
+            >
               Nome do Roteiro (opcional)
             </Label>
             <Input
+              id="script-name"
               type="text"
               value={scriptName}
               onChange={(e) => onUpdateField('scriptName', e.target.value)}
@@ -279,9 +283,12 @@ export default function ScriptSection({
                   </div>
 
                   <div>
-                    <Label className="text-sm font-medium">Link do Arquivo</Label>
+                    <Label htmlFor="attachment-url" className="text-sm font-medium">
+                      Link do Arquivo
+                    </Label>
                     <div className="mt-1 space-y-3">
                       <Input
+                        id="attachment-url"
                         type="url"
                         value={newAttachmentUrl}
                         onChange={(e) => setNewAttachmentUrl(e.target.value)}


### PR DESCRIPTION
## Summary
- add unique ids to inputs in production info, contacts, call times, locations, scenes, and script sections
- link labels to the new ids for better accessibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896678ea6c8832c8d31874c66872222