### PR TITLE
feat: close database on shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ Ao executar scripts Node ou testes que utilizem `fetch`, defina
 `API_BASE_URL` ou `VITE_API_BASE_URL`. Em produção essas variáveis devem
 usar HTTPS ou permanecer vazias para evitar avisos de conteúdo misto.
 
+Durante o encerramento do processo (sinais `SIGINT` ou `SIGTERM`), a aplicação fecha a conexão com o banco de dados antes de finalizar.
+
 ## 🤝 Contribuição
 
 1. Fork o projeto

--- a/server/db.ts
+++ b/server/db.ts
@@ -38,3 +38,13 @@ export async function testConnection() {
     return false;
   }
 }
+
+// Close database connection gracefully
+export async function closeDb() {
+  try {
+    await client?.end?.();
+    await client?.close?.();
+  } catch (error: any) {
+    console.error('Error closing database connection:', error.message);
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { errorHandler } from "./error-handler";
+import { closeDb } from "./db";
 
 const app = express();
 app.use(express.json());
@@ -47,3 +48,12 @@ app.use((req, res, next) => {
     log(`serving on port ${port}`);
   });
 })();
+
+async function shutdown(signal: string) {
+  log(`Received ${signal}, shutting down...`);
+  await closeDb();
+  process.exit(0);
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));


### PR DESCRIPTION
## Summary
- add `closeDb` helper to end postgres client
- call `closeDb` on SIGINT and SIGTERM before exiting
- document graceful shutdown behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689776402240832c9ec14552b890d483