### PR TITLE
feat: improve API request error handling

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,23 +1,54 @@
 const API_BASE =
-  typeof window === 'undefined'
-    ? process.env.API_BASE_URL || ''
-    : import.meta.env.VITE_API_BASE_URL || '';
+  typeof window === "undefined"
+    ? process.env.API_BASE_URL || ""
+    : import.meta.env.VITE_API_BASE_URL || "";
+
+export class ApiError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
 
 export async function apiRequest<T = unknown>(
   path: string,
-  options?: RequestInit,
+  options: RequestInit = {},
 ): Promise<T | undefined> {
   const url = API_BASE ? new URL(path, API_BASE).toString() : path;
-  const response = await fetch(url, options);
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
-  }
+  const { method = "GET", headers, ...rest } = options;
+  const init: RequestInit = {
+    method,
+    ...rest,
+    headers: {
+      ...(method === "POST" || method === "PUT"
+        ? { "Content-Type": "application/json" }
+        : {}),
+      ...headers,
+    },
+  };
 
-  if (response.status === 204 || response.headers.get("content-length") === "0") {
-    return undefined;
-  }
+  try {
+    const response = await fetch(url, init);
+    if (!response.ok) {
+      throw new ApiError(
+        `Erro ${response.status}. Por favor, tente novamente mais tarde.`,
+      );
+    }
 
-  return response.json() as Promise<T>;
+    if (
+      response.status === 204 ||
+      response.headers.get("content-length") === "0"
+    ) {
+      return undefined;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new ApiError("Falha de rede. Verifique sua conexão.");
+    }
+    throw error;
+  }
 }
 
 export { API_BASE };

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -1,10 +1,10 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
-import { API_BASE } from "@/lib/api";
+import { API_BASE, ApiError } from "@/lib/api";
 
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
-    throw new Error(`${res.status}: ${text}`);
+    throw new ApiError(`Erro ${res.status}. ${text}`);
   }
 }
 
@@ -14,15 +14,27 @@ export async function apiRequest(
   data?: unknown | undefined,
 ): Promise<Response> {
   const fullUrl = new URL(url, API_BASE).toString();
-  const res = await fetch(fullUrl, {
-    method,
-    headers: data ? { "Content-Type": "application/json" } : {},
-    body: data ? JSON.stringify(data) : undefined,
-    credentials: "include",
-  });
+  const headers: HeadersInit =
+    method === "POST" || method === "PUT"
+      ? { "Content-Type": "application/json" }
+      : {};
 
-  await throwIfResNotOk(res);
-  return res;
+  try {
+    const res = await fetch(fullUrl, {
+      method,
+      headers,
+      body: data ? JSON.stringify(data) : undefined,
+      credentials: "include",
+    });
+
+    await throwIfResNotOk(res);
+    return res;
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new ApiError("Falha de rede. Verifique sua conexão.");
+    }
+    throw error;
+  }
 }
 
 type UnauthorizedBehavior = "returnNull" | "throw";
@@ -32,16 +44,23 @@ export const getQueryFn: <T>(options: {
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
     const url = new URL(queryKey.join("/") as string, API_BASE).toString();
-    const res = await fetch(url, {
-      credentials: "include",
-    });
+    try {
+      const res = await fetch(url, {
+        credentials: "include",
+      });
 
-    if (unauthorizedBehavior === "returnNull" && res.status === 401) {
-      return null;
+      if (unauthorizedBehavior === "returnNull" && res.status === 401) {
+        return null;
+      }
+
+      await throwIfResNotOk(res);
+      return await res.json();
+    } catch (error) {
+      if (error instanceof TypeError) {
+        throw new ApiError("Falha de rede. Verifique sua conexão.");
+      }
+      throw error;
     }
-
-    await throwIfResNotOk(res);
-    return await res.json();
   };
 
 export const queryClient = new QueryClient({


### PR DESCRIPTION
## Summary
- add ApiError class and wrap fetch calls for network failure handling
- apply default JSON headers for POST/PUT requests
- integrate resilient error handling in query client utilities

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897763852e4832cbe71bed687e6eb57